### PR TITLE
1.10.0

### DIFF
--- a/.run/CodeGenerator.run.xml
+++ b/.run/CodeGenerator.run.xml
@@ -1,23 +1,3 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="CodeGenerator" type="PythonConfigurationType" factoryName="Python" nameIsGenerated="true">
-    <module name="rider.module" />
-    <option name="INTERPRETER_OPTIONS" value="" />
-    <option name="PARENT_ENVS" value="true" />
-    <envs>
-      <env name="PYTHONUNBUFFERED" value="1" />
-    </envs>
-    <option name="SDK_HOME" value="C:\Python39\python.exe" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="IS_MODULE_SDK" value="true" />
-    <option name="ADD_CONTENT_ROOTS" value="true" />
-    <option name="ADD_SOURCE_ROOTS" value="true" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/CodeGenerator.py" />
-    <option name="PARAMETERS" value="" />
-    <option name="SHOW_COMMAND_LINE" value="false" />
-    <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="false" />
-    <option name="REDIRECT_INPUT" value="false" />
-    <option name="INPUT_FILE" value="" />
-    <method v="2" />
-  </configuration>
+  <configuration />
 </component>

--- a/ClientPlugin/GUI/PluginConfigDialog.cs
+++ b/ClientPlugin/GUI/PluginConfigDialog.cs
@@ -67,6 +67,21 @@ namespace ClientPlugin.GUI
         private MyGuiControlLabel fixEndShootLabel;
         private MyGuiControlCheckbox fixEndShootCheckbox;
 
+        private MyGuiControlLabel fixAccessLabel;
+        private MyGuiControlCheckbox fixAccessCheckbox;
+
+        private MyGuiControlLabel fixBroadcastLabel;
+        private MyGuiControlCheckbox fixBroadcastCheckbox;
+
+        private MyGuiControlLabel fixBlockLimitLabel;
+        private MyGuiControlCheckbox fixBlockLimitCheckbox;
+
+        private MyGuiControlLabel fixSafeActionLabel;
+        private MyGuiControlCheckbox fixSafeActionCheckbox;
+
+        private MyGuiControlLabel fixTerminalLabel;
+        private MyGuiControlCheckbox fixTerminalCheckbox;
+
         /*BOOL_OPTION
         private MyGuiControlLabel optionNameLabel;
         private MyGuiControlCheckbox optionNameCheckbox;
@@ -78,7 +93,7 @@ namespace ClientPlugin.GUI
         private MyGuiControlMultilineText infoText;
         private MyGuiControlButton closeButton;
 
-        public PluginConfigDialog() : base(new Vector2(0.5f, 0.5f), MyGuiConstants.SCREEN_BACKGROUND_COLOR, new Vector2(0.8f, 0.8f), false, null, MySandboxGame.Config.UIBkOpacity, MySandboxGame.Config.UIOpacity)
+        public PluginConfigDialog() : base(new Vector2(0.5f, 0.5f), MyGuiConstants.SCREEN_BACKGROUND_COLOR, new Vector2(0.9f, 0.9f), false, null, MySandboxGame.Config.UIBkOpacity, MySandboxGame.Config.UIOpacity)
         {
             EnabledBackgroundFade = true;
             m_closeOnEsc = true;
@@ -126,6 +141,11 @@ namespace ClientPlugin.GUI
             CreateCheckbox(out fixCharacterLabel, out fixCharacterCheckbox, config.FixCharacter, value => config.FixCharacter = value, "Fix character performance (needs restart)", "Disables character footprint logic on server side (needs restart)");
             CreateCheckbox(out fixMemoryLabel, out fixMemoryCheckbox, config.FixMemory, value => config.FixMemory = value, "Fix frequent memory allocations", "Optimizes frequent memory allocations in various parts of the game");
             CreateCheckbox(out fixEndShootLabel, out fixEndShootCheckbox, config.FixEndShoot, value => config.FixEndShoot = value, "Fix crash on grinding active turrets", "Adds a missing call to EndShoot on server side, fixing subsequent issues on client side");
+            CreateCheckbox(out fixAccessLabel, out fixAccessCheckbox, config.FixAccess, value => config.FixAccess = value, "Less frequent update of block access rights", "Caches the result of MyCubeBlock.GetUserRelationToOwner and MyTerminalBlock.HasPlayerAccessReason");
+            CreateCheckbox(out fixBroadcastLabel, out fixBroadcastCheckbox, config.FixBroadcast, value => config.FixBroadcast = value, "Reduced memory allocation in broadcaster scanning", "Reduces memory allocations in MyDataReceiver.UpdateBroadcastersInRange (needs restart)");
+            CreateCheckbox(out fixBlockLimitLabel, out fixBlockLimitCheckbox, config.FixBlockLimit, value => config.FixBlockLimit = value, "Less frequent sync of block counts for limit checking", "Suppresses frequent calls to MyPlayerCollection.SendDirtyBlockLimits");
+            CreateCheckbox(out fixSafeActionLabel, out fixSafeActionCheckbox, config.FixSafeAction, value => config.FixSafeAction = value, "Cache actions allowed by the safe zone", "Caches the result of MySafeZone.IsActionAllowed and MySessionComponentSafeZones.IsActionAllowedForSafezone for 2 seconds");
+            CreateCheckbox(out fixTerminalLabel, out fixTerminalCheckbox, config.FixTerminal, value => config.FixTerminal = value, "Less frequent update of PB access to blocks", "Suppresses frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership updating IsAccessibleForProgrammableBlock unnecessarily often");
             //BOOL_OPTION CreateCheckbox(out optionNameLabel, out optionNameCheckbox, config.OptionName, value => config.OptionName = value, "Option label", "Option tooltip");
 
             EnableDisableFixes();
@@ -183,14 +203,19 @@ namespace ClientPlugin.GUI
             fixCharacterCheckbox.Enabled = enabled;
             fixMemoryCheckbox.Enabled = enabled;
             fixEndShootCheckbox.Enabled = enabled;
+            fixAccessCheckbox.Enabled = enabled;
+            fixBroadcastCheckbox.Enabled = enabled;
+            fixBlockLimitCheckbox.Enabled = enabled;
+            fixSafeActionCheckbox.Enabled = enabled;
+            fixTerminalCheckbox.Enabled = enabled;
             //BOOL_OPTION optionNameCheckbox.Enabled = enabled;
         }
 
         private void LayoutControls()
         {
-            layoutTable = new MyLayoutTable(this, new Vector2(-0.35f, -0.3f), new Vector2(0.7f, 0.6f));
+            layoutTable = new MyLayoutTable(this, new Vector2(-0.4f, -0.4f), new Vector2(0.8f, 0.8f));
             layoutTable.SetColumnWidths(60f, 440f, 60f, 440f);
-            layoutTable.SetRowHeights(150f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 150f);
+            layoutTable.SetRowHeights(150f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 60f, 150f);
 
             layoutTable.Add(enabledCheckbox, MyAlignH.Left, MyAlignV.Center, 0, 0);
             layoutTable.Add(enabledLabel, MyAlignH.Left, MyAlignV.Center, 0, 1);
@@ -231,16 +256,15 @@ namespace ClientPlugin.GUI
 
             layoutTable.Add(fixSafeZoneCheckbox, MyAlignH.Left, MyAlignV.Center, row, 0);
             layoutTable.Add(fixSafeZoneLabel, MyAlignH.Left, MyAlignV.Center, row, 1);
+            row++;
 
+            layoutTable.Add(fixTargetingCheckbox, MyAlignH.Left, MyAlignV.Center, row, 0);
+            layoutTable.Add(fixTargetingLabel, MyAlignH.Left, MyAlignV.Center, row, 1);
+            row++;
+
+            layoutTable.Add(fixWindTurbineCheckbox, MyAlignH.Left, MyAlignV.Center, row, 0);
+            layoutTable.Add(fixWindTurbineLabel, MyAlignH.Left, MyAlignV.Center, row, 1);
             row = 1;
-
-            layoutTable.Add(fixTargetingCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
-            layoutTable.Add(fixTargetingLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
-            row++;
-
-            layoutTable.Add(fixWindTurbineCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
-            layoutTable.Add(fixWindTurbineLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
-            row++;
 
             layoutTable.Add(fixVoxelCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
             layoutTable.Add(fixVoxelLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
@@ -264,15 +288,36 @@ namespace ClientPlugin.GUI
 
             layoutTable.Add(fixEndShootCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
             layoutTable.Add(fixEndShootLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
-            /*BOOL_OPTION
             row++;
 
+            layoutTable.Add(fixAccessCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
+            layoutTable.Add(fixAccessLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
+            row++;
+
+            layoutTable.Add(fixBroadcastCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
+            layoutTable.Add(fixBroadcastLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
+            row++;
+
+            layoutTable.Add(fixBlockLimitCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
+            layoutTable.Add(fixBlockLimitLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
+            row++;
+
+            layoutTable.Add(fixSafeActionCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
+            layoutTable.Add(fixSafeActionLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
+            row++;
+
+            layoutTable.Add(fixTerminalCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
+            layoutTable.Add(fixTerminalLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
+            row++;
+
+            /*BOOL_OPTION
             layoutTable.Add(optionNameCheckbox, MyAlignH.Left, MyAlignV.Center, row, 2);
             layoutTable.Add(optionNameLabel, MyAlignH.Left, MyAlignV.Center, row, 3);
-            BOOL_OPTION*/
+            row++;
 
-            layoutTable.Add(infoText, MyAlignH.Left, MyAlignV.Top, 10, 0, colSpan: 2);
-            layoutTable.Add(closeButton, MyAlignH.Center, MyAlignV.Center, 10, 2, colSpan: 2);
+            BOOL_OPTION*/
+            layoutTable.Add(infoText, MyAlignH.Left, MyAlignV.Top, row, 0, colSpan: 2);
+            layoutTable.Add(closeButton, MyAlignH.Center, MyAlignV.Center, row, 2, colSpan: 2);
         }
     }
 }

--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.2.0")]
-[assembly: AssemblyFileVersion("1.9.2.0")]
+[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyFileVersion("1.10.0.0")]

--- a/CodeGenerator.py
+++ b/CodeGenerator.py
@@ -128,7 +128,11 @@ def generate_bool_option(name, command, label, tooltip):
 
 def main():
     pass
-    # generate_bool_option('FixEndShoot', 'endshoot', 'Fix crash on grinding active turrets', 'Adds a missing call to EndShoot on server side, fixing subsequent issues on client side')
+    # generate_bool_option('FixAccess', 'access', 'Less frequent update of block access rights', 'Caches the result of MyCubeBlock.GetUserRelationToOwner and MyTerminalBlock.HasPlayerAccessReason')
+    # generate_bool_option('FixBroadcast', 'broadcast', 'Reduced memory allocation in broadcaster scanning', 'Reduces memory allocations in MyDataReceiver.UpdateBroadcastersInRange (needs restart)')
+    # generate_bool_option('FixBlockLimit', 'block_limit', 'Less frequent sync of block counts for limit checking', 'Suppresses frequent calls to MyPlayerCollection.SendDirtyBlockLimits')
+    # generate_bool_option('FixSafeAction', 'safe_action', 'Cache actions allowed by the safe zone', 'Caches the result of MySafeZone.IsActionAllowed and MySessionComponentSafeZones.IsActionAllowedForSafezone for 2 seconds')
+    # generate_bool_option('FixTerminal', 'terminal', 'Less frequent update of PB access to blocks', 'Suppresses frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership updating IsAccessibleForProgrammableBlock unnecessarily often')
 
 
 if __name__ == '__main__':

--- a/DedicatedPlugin/Properties/AssemblyInfo.cs
+++ b/DedicatedPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.2.0")]
-[assembly: AssemblyFileVersion("1.9.2.0")]
+[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyFileVersion("1.10.0.0")]

--- a/README.md
+++ b/README.md
@@ -217,3 +217,33 @@ which crashes clients grinding active turrets. Added defensive `null` checks to
 `MyLargeTurretBase.UpdateShooting` just in case the server would not have the fix.  
 
 TBD: Bug ticket with a world to 100% reproduce this issue.
+
+### Less frequent update of block access rights
+
+Caches the result of MyCubeBlock.GetUserRelationToOwner and MyTerminalBlock.HasPlayerAccessReason.
+
+TBD: Bug ticket
+
+### Reduced memory allocation in broadcaster scanning
+
+Reduces memory allocations in MyDataReceiver.UpdateBroadcastersInRange (needs restart).
+
+TBD: Bug ticket
+
+### Less frequent sync of block counts for limit checking
+
+Suppresses frequent calls to MyPlayerCollection.SendDirtyBlockLimits.
+
+TBD: Bug ticket
+
+### Cache actions allowed by the safe zone
+
+Caches the result of MySafeZone.IsActionAllowed and MySessionComponentSafeZones.IsActionAllowedForSafezone for 2 seconds.
+
+TBD: Bug ticket
+
+### Less frequent update of PB access to blocks
+
+Suppresses frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership updating IsAccessibleForProgrammableBlock unnecessarily often.
+
+TBD: Bug ticket

--- a/Shared/Config/IPluginConfig.cs
+++ b/Shared/Config/IPluginConfig.cs
@@ -61,6 +61,21 @@ namespace Shared.Config
         // Adds a missing call to EndShoot on server side, fixing subsequent issues on client side
         bool FixEndShoot { get; set; }
 
+        // Caches the result of MyCubeBlock.GetUserRelationToOwner and MyTerminalBlock.HasPlayerAccessReason
+        bool FixAccess { get; set; }
+
+        // Reduces memory allocations in MyDataReceiver.UpdateBroadcastersInRange (needs restart)
+        bool FixBroadcast { get; set; }
+
+        // Suppresses frequent calls to MyPlayerCollection.SendDirtyBlockLimits
+        bool FixBlockLimit { get; set; }
+
+        // Caches the result of MySafeZone.IsActionAllowed and MySessionComponentSafeZones.IsActionAllowedForSafezone for 2 seconds
+        bool FixSafeAction { get; set; }
+
+        // Suppresses frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership updating IsAccessibleForProgrammableBlock unnecessarily often
+        bool FixTerminal { get; set; }
+
         /*BOOL_OPTION
         // Option tooltip
         bool OptionName { get; set; }

--- a/Shared/Config/PluginConfig.cs
+++ b/Shared/Config/PluginConfig.cs
@@ -48,6 +48,11 @@ namespace Shared.Config
         private bool fixCharacter = true;
         private bool fixMemory = true;
         private bool fixEndShoot = true;
+        private bool fixAccess = true;
+        private bool fixBroadcast = true;
+        private bool fixBlockLimit = true;
+        private bool fixSafeAction = true;
+        private bool fixTerminal = true;
         //BOOL_OPTION private bool optionName = true;
 
         public bool Enabled
@@ -162,6 +167,36 @@ namespace Shared.Config
         {
             get => fixEndShoot;
             set => SetValue(ref fixEndShoot, value);
+        }
+
+        public bool FixAccess
+        {
+            get => fixAccess;
+            set => SetValue(ref fixAccess, value);
+        }
+
+        public bool FixBroadcast
+        {
+            get => fixBroadcast;
+            set => SetValue(ref fixBroadcast, value);
+        }
+
+        public bool FixBlockLimit
+        {
+            get => fixBlockLimit;
+            set => SetValue(ref fixBlockLimit, value);
+        }
+
+        public bool FixSafeAction
+        {
+            get => fixSafeAction;
+            set => SetValue(ref fixSafeAction, value);
+        }
+
+        public bool FixTerminal
+        {
+            get => fixTerminal;
+            set => SetValue(ref fixTerminal, value);
         }
 
         /*BOOL_OPTION

--- a/Shared/Patches/Block/MyCubeBlockPatch.cs
+++ b/Shared/Patches/Block/MyCubeBlockPatch.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Sandbox.Game.Entities;
+using Shared.Config;
+using Shared.Plugin;
+using Shared.Tools;
+using TorchPlugin.Shared.Tools;
+using VRage.Game;
+
+namespace Shared.Patches
+{
+    [HarmonyPatch(typeof(MyCubeBlock))]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    // ReSharper disable once UnusedType.Global
+    public static class MyCubeBlockPatch
+    {
+        private static IPluginConfig Config => Common.Config;
+        private static bool enabled;
+
+        public static void Configure()
+        {
+            enabled = Config.Enabled && Config.FixAccess;
+            Config.PropertyChanged += OnConfigChanged;
+        }
+
+        private static void OnConfigChanged(object sender, PropertyChangedEventArgs e)
+        {
+            enabled = Config.Enabled && Config.FixAccess;
+            if (!enabled)
+                Cache.Clear();
+        }
+
+        private static readonly UintCache<long> Cache = new UintCache<long>(397 * 60, 2048);
+
+#if DEBUG
+        public static string CacheReport => Cache.Report;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Update()
+        {
+            Cache.Cleanup();
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MyCubeBlock.GetUserRelationToOwner))]
+        [EnsureCode("6a33d947")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool GetUserRelationToOwnerPrefix(MyCubeBlock __instance, long identityId, MyRelationsBetweenPlayerAndBlock defaultNoUser, ref MyRelationsBetweenPlayerAndBlock __result, ref long __state)
+        {
+            if (!enabled)
+                return true;
+
+            var key = __instance.EntityId ^ identityId ^ (long)defaultNoUser;
+            if (Cache.TryGetValue(key, out var value))
+            {
+                // Call the original in case of cache collisions (very low probability)
+                value ^= (uint)identityId;
+                if (value > (uint)MyRelationsBetweenPlayerAndBlock.Friends)
+                    return true;
+
+                __result = (MyRelationsBetweenPlayerAndBlock)value;
+                return false;
+            }
+
+            __state = key;
+            return false;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(MyCubeBlock.GetUserRelationToOwner))]
+        [EnsureCode("6a33d947")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void GetUserRelationToOwnerPostfix(long identityId, MyRelationsBetweenPlayerAndBlock __result, long __state)
+        {
+            if (__state == 0)
+                return;
+
+            Cache.Store(__state, (uint)__result ^ (uint)identityId, 15 * 60 + ((uint)__state & 255));
+        }
+    }
+}

--- a/Shared/Patches/Block/MyTerminalBlockPatch.cs
+++ b/Shared/Patches/Block/MyTerminalBlockPatch.cs
@@ -1,0 +1,86 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Sandbox.Game.Entities;
+using Sandbox.Game.Entities.Cube;
+using Shared.Config;
+using Shared.Plugin;
+using Shared.Tools;
+using TorchPlugin.Shared.Tools;
+using VRage.Game;
+
+namespace Shared.Patches
+{
+    [HarmonyPatch(typeof(MyTerminalBlock))]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    // ReSharper disable once UnusedType.Global
+    public static class MyTerminalBlockPatch
+    {
+        private static IPluginConfig Config => Common.Config;
+        private static bool enabled;
+
+        public static void Configure()
+        {
+            enabled = Config.Enabled && Config.FixAccess; // !!!
+            Config.PropertyChanged += OnConfigChanged;
+        }
+
+        private static void OnConfigChanged(object sender, PropertyChangedEventArgs e)
+        {
+            enabled = Config.Enabled && Config.FixAccess;
+            if (!enabled)
+                Cache.Clear();
+        }
+
+        private static readonly UintCache<long> Cache = new UintCache<long>(317 * 60, 2048);
+
+#if DEBUG
+        public static string CacheReport => Cache.Report;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Update()
+        {
+            Cache.Cleanup();
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MyTerminalBlock.HasPlayerAccessReason))]
+        [EnsureCode("1f8f024a")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HasPlayerAccessReasonPrefix(MyCubeBlock __instance, long identityId, MyRelationsBetweenPlayerAndBlock defaultNoUser, ref MyTerminalBlock.AccessRightsResult __result, ref long __state)
+        {
+            if (!enabled)
+                return true;
+
+            var key = __instance.EntityId ^ identityId ^ (long)defaultNoUser;
+            if (Cache.TryGetValue(key, out var value))
+            {
+                // Call the original in case of a cache collision (very low probability)
+                value ^= (uint)identityId;
+                if (value > (uint)MyTerminalBlock.AccessRightsResult.None)
+                    return true;
+
+                __result = (MyTerminalBlock.AccessRightsResult)value;
+                return false;
+            }
+
+            __state = key;
+            return false;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(MyTerminalBlock.HasPlayerAccessReason))]
+        [EnsureCode("1f8f024a")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void HasPlayerAccessReasonPostfix(long identityId, MyTerminalBlock.AccessRightsResult __result, long __state)
+        {
+            if (__state == 0)
+                return;
+
+            Cache.Store(__state, (uint)__result ^ (uint)identityId, 12 * 60 + ((uint)__state & 511));
+        }
+    }
+}

--- a/Shared/Patches/Conveyor/MyPathfindingDataPatch.cs
+++ b/Shared/Patches/Conveyor/MyPathfindingDataPatch.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using HarmonyLib;
+using Shared.Tools;
+using VRage.Algorithms;
+
+namespace Shared.Patches.Conveyor
+{
+    [HarmonyPatch(typeof(MyPathfindingData))]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    // ReSharper disable once UnusedType.Global
+    public static class MyPathfindingDataPatch
+    {
+        // These methods are called a lot, therefore this fix cannot be disabled.
+        // FIXME: Turn them into transpiler patches and add configurability.
+
+        [HarmonyPostfix]
+        [HarmonyPatch(MethodType.Constructor, typeof(object))]
+        [EnsureCode("7badc1eb")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void TimestampCtorPostfix(out object ___m_lockObject)
+        {
+            ___m_lockObject = new RwLockCounter();
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("Timestamp", MethodType.Setter)]
+        [EnsureCode("af65d019")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TimestampSetterPrefix(object ___m_lockObject, Dictionary<Thread, long> ___threadedTimestamp, long value)
+        {
+            if (!(___m_lockObject is RwLockCounter rwLock))
+            {
+                // ReSharper disable once RedundantAssignment
+                ___m_lockObject = rwLock = new RwLockCounter();
+            }
+
+            rwLock.AcquireForWriting();
+            ___threadedTimestamp[Thread.CurrentThread] = value;
+            rwLock.ReleaseAfterWriting();
+
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch("Timestamp", MethodType.Getter)]
+        [EnsureCode("8e608197")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TimestampGetterPrefix(object ___m_lockObject, Dictionary<Thread, long> ___threadedTimestamp, out long __result)
+        {
+            if (!(___m_lockObject is RwLockCounter rwLock))
+            {
+                // ReSharper disable once RedundantAssignment
+                ___m_lockObject = rwLock = new RwLockCounter();
+            }
+
+            rwLock.AcquireForReading();
+            ___threadedTimestamp.TryGetValue(Thread.CurrentThread, out __result);
+            rwLock.ReleaseAfterReading();
+
+            return false;
+        }
+    }
+}

--- a/Shared/Patches/Memory/MyDataReceiverPatch.cs
+++ b/Shared/Patches/Memory/MyDataReceiverPatch.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using HarmonyLib;
+using Sandbox.Game.Entities;
+using Shared.Config;
+using Shared.Plugin;
+using Shared.Tools;
+
+namespace Shared.Patches
+{
+    [HarmonyPatch(typeof(MyDataReceiver))]
+    [SuppressMessage("ReSharper", "UnusedType.Global")]
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    public static class MyDataReceiverPatch
+    {
+        private static IPluginConfig Config => Common.Config;
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(MyDataReceiver.UpdateBroadcastersInRange))]
+        [EnsureCode("34748389")]
+        private static IEnumerable<CodeInstruction> UpdateBroadcastersInRangeTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            if (!Config.Enabled || !Config.FixBroadcast)
+                return instructions;
+
+            var il = instructions.ToList();
+            il.RecordOriginalCode();
+
+            var i = il.FindIndex(ci => ci.opcode == OpCodes.Newobj);
+            Debug.Assert(il[i + 2].opcode == OpCodes.Newobj);
+
+            var getHashSet = AccessTools.DeclaredMethod(typeof(MyDataReceiverPatch), nameof(GetHashSet));
+
+            il.RemoveAt(i);
+            il.Insert(i++, new CodeInstruction(OpCodes.Ldc_I4_0));
+            il.Insert(i++, new CodeInstruction(OpCodes.Call, getHashSet));
+
+            i++;
+
+            il.RemoveAt(i);
+            il.Insert(i++, new CodeInstruction(OpCodes.Ldc_I4_1));
+            il.Insert(i, new CodeInstruction(OpCodes.Call, getHashSet));
+
+            il.RecordPatchedCode();
+            return il;
+        }
+
+        private static readonly ThreadLocal<HashSet<long>[]> Pool = new ThreadLocal<HashSet<long>[]>();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static HashSet<long> GetHashSet(int i)
+        {
+            var hashSets = Pool.Value;
+            if (hashSets == null)
+            {
+                hashSets = new[]
+                {
+                    new HashSet<long>(),
+                    new HashSet<long>()
+                };
+                Pool.Value = hashSets;
+            }
+
+            var hashSet = hashSets[i];
+            hashSet.Clear();
+            return hashSet;
+        }
+    }
+}

--- a/Shared/Patches/Memory/MyDefinitionIdToStringPatch.cs
+++ b/Shared/Patches/Memory/MyDefinitionIdToStringPatch.cs
@@ -1,5 +1,6 @@
+// #define VERIFY_RESULT
+
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using HarmonyLib;
@@ -62,7 +63,7 @@ namespace Shared.Patches
 
             if (Cache.TryGetValue(__instance.GetHashCodeLong(), out __result))
             {
-#if DEBUG
+#if DEBUG && VERIFY_RESULT
                 var expectedName = Format(__instance);
                 Debug.Assert(__result == expectedName);
 #endif

--- a/Shared/Patches/Memory/MyPlayerCollectionPatch.cs
+++ b/Shared/Patches/Memory/MyPlayerCollectionPatch.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using Sandbox.Game.Multiplayer;
+using Shared.Config;
+using Shared.Plugin;
+
+namespace Shared.Patches
+{
+    [HarmonyPatch(typeof(MyPlayerCollection))]
+    [SuppressMessage("ReSharper", "UnusedType.Global")]
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public static class MyPlayerCollectionPatch
+    {
+        private static IPluginConfig Config => Common.Config;
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MyPlayerCollection.SendDirtyBlockLimits))]
+        public static bool SendDirtyBlockLimitsPrefix()
+        {
+            if (!Config.Enabled || !Config.FixBlockLimit)
+                return true;
+
+            return Common.Plugin.Tick % 180 == 0;
+        }
+    }
+}

--- a/Shared/Patches/Memory/UpdateBroadcastersInRange.original.il
+++ b/Shared/Patches/Memory/UpdateBroadcastersInRange.original.il
@@ -1,0 +1,187 @@
+// 34748389
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt virtual System.Void System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::Clear()
+ldsfld System.Boolean Sandbox.Engine.Utils.MyFakes::ENABLE_RADIO_HUD
+brfalse.s L0
+ldarg.0
+call System.Boolean Sandbox.Game.Entities.MyDataReceiver::get_Enabled()
+brtrue.s L1
+L0:
+ret
+L1:
+ldarg.0
+call VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+callvirt abstract virtual VRage.Game.Components.MyEntityComponentContainer VRage.ModAPI.IMyEntity::get_Components()
+ldloca.s 0 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Boolean VRage.Game.Components.MyComponentContainer::TryGet(Sandbox.Game.Entities.MyDataBroadcaster& component)
+brfalse.s L2
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+ldloc.0
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::Add(Sandbox.Game.Entities.MyDataBroadcaster item)
+pop
+L2:
+ldarg.0
+ldarg.0
+ldflda System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt abstract virtual System.Void Sandbox.Game.Entities.MyDataReceiver::GetBroadcastersInMyRange(System.Collections.Generic.HashSet`1& broadcastersInRange)
+newobj System.Void System.Collections.Generic.HashSet`1<System.Int64>::.ctor()
+stloc.1
+newobj System.Void System.Collections.Generic.HashSet`1<System.Int64>::.ctor()
+stloc.2
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster> System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::GetEnumerator()
+stloc.3
+[EX_BeginException]
+br.s L3
+L5:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::get_Current()
+stloc.s 4 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 4 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L4
+ldloc.1
+ldloc.s 4 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Int64 Sandbox.Game.Entities.MyDataBroadcaster::get_AntennaEntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Add(System.Int64 item)
+pop
+L3:
+L4:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual System.Boolean System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::MoveNext()
+brtrue.s L5
+leave.s L6
+[EX_BeginFinally]
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+constrained. System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster]
+callvirt abstract virtual System.Void System.IDisposable::Dispose()
+[EX_EndException]
+endfinally
+L6:
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+callvirt System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster> System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::GetEnumerator()
+stloc.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+[EX_BeginException]
+br.s L7
+L9:
+ldloca.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::get_Current()
+stloc.s 6 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 6 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L8
+ldloc.2
+ldloc.s 6 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Int64 Sandbox.Game.Entities.MyDataBroadcaster::get_AntennaEntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Add(System.Int64 item)
+pop
+L7:
+L8:
+ldloca.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual System.Boolean System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::MoveNext()
+brtrue.s L9
+leave.s L10
+[EX_BeginFinally]
+ldloca.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+constrained. System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster]
+callvirt abstract virtual System.Void System.IDisposable::Dispose()
+[EX_EndException]
+endfinally
+L10:
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+callvirt virtual System.Int32 System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::get_Count()
+ldc.i4.1
+sub
+stloc.s 7 (System.Int32)
+br.s L11
+L16:
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+ldloc.s 7 (System.Int32)
+callvirt virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::get_Item(System.Int32 index)
+stloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L12
+ldloc.2
+ldloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+callvirt abstract virtual System.Int64 VRage.ModAPI.IMyEntity::get_EntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Contains(System.Int64 item)
+brtrue.s L13
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+ldloc.s 7 (System.Int32)
+call static System.Void System.Collections.Generic.ListExtensions::RemoveAtFast(System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> list, System.Int32 index)
+ldarg.0
+ldfld Sandbox.Game.Entities.BroadcasterChangeInfo Sandbox.Game.Entities.MyDataReceiver::OnBroadcasterLost
+dup
+brtrue.s L14
+pop
+br.s L15
+L14:
+ldloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt virtual System.Void Sandbox.Game.Entities.BroadcasterChangeInfo::Invoke(Sandbox.Game.Entities.MyDataBroadcaster broadcaster)
+L12:
+L13:
+L15:
+ldloc.s 7 (System.Int32)
+ldc.i4.1
+sub
+stloc.s 7 (System.Int32)
+L11:
+ldloc.s 7 (System.Int32)
+ldc.i4.0
+bge.s L16
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster> System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::GetEnumerator()
+stloc.3
+[EX_BeginException]
+br.s L17
+L22:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::get_Current()
+stloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L18
+ldloc.2
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Int64 Sandbox.Game.Entities.MyDataBroadcaster::get_AntennaEntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Contains(System.Int64 item)
+brtrue.s L19
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt virtual System.Void System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::Add(Sandbox.Game.Entities.MyDataBroadcaster item)
+ldarg.0
+ldfld Sandbox.Game.Entities.BroadcasterChangeInfo Sandbox.Game.Entities.MyDataReceiver::OnBroadcasterFound
+dup
+brtrue.s L20
+pop
+br.s L21
+L20:
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt virtual System.Void Sandbox.Game.Entities.BroadcasterChangeInfo::Invoke(Sandbox.Game.Entities.MyDataBroadcaster broadcaster)
+L17:
+L18:
+L19:
+L21:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual System.Boolean System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::MoveNext()
+brtrue.s L22
+leave.s L23
+[EX_BeginFinally]
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+constrained. System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster]
+callvirt abstract virtual System.Void System.IDisposable::Dispose()
+[EX_EndException]
+endfinally
+L23:
+ret

--- a/Shared/Patches/Memory/UpdateBroadcastersInRange.patched.il
+++ b/Shared/Patches/Memory/UpdateBroadcastersInRange.patched.il
@@ -1,0 +1,189 @@
+// 597b1d37
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt virtual System.Void System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::Clear()
+ldsfld System.Boolean Sandbox.Engine.Utils.MyFakes::ENABLE_RADIO_HUD
+brfalse.s L0
+ldarg.0
+call System.Boolean Sandbox.Game.Entities.MyDataReceiver::get_Enabled()
+brtrue.s L1
+L0:
+ret
+L1:
+ldarg.0
+call VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+callvirt abstract virtual VRage.Game.Components.MyEntityComponentContainer VRage.ModAPI.IMyEntity::get_Components()
+ldloca.s 0 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Boolean VRage.Game.Components.MyComponentContainer::TryGet(Sandbox.Game.Entities.MyDataBroadcaster& component)
+brfalse.s L2
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+ldloc.0
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::Add(Sandbox.Game.Entities.MyDataBroadcaster item)
+pop
+L2:
+ldarg.0
+ldarg.0
+ldflda System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt abstract virtual System.Void Sandbox.Game.Entities.MyDataReceiver::GetBroadcastersInMyRange(System.Collections.Generic.HashSet`1& broadcastersInRange)
+ldc.i4.0
+call static System.Collections.Generic.HashSet`1<System.Int64> Shared.Patches.MyDataReceiverPatch::GetHashSet(System.Int32 i)
+stloc.1
+ldc.i4.1
+call static System.Collections.Generic.HashSet`1<System.Int64> Shared.Patches.MyDataReceiverPatch::GetHashSet(System.Int32 i)
+stloc.2
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster> System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::GetEnumerator()
+stloc.3
+[EX_BeginException]
+br.s L3
+L5:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::get_Current()
+stloc.s 4 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 4 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L4
+ldloc.1
+ldloc.s 4 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Int64 Sandbox.Game.Entities.MyDataBroadcaster::get_AntennaEntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Add(System.Int64 item)
+pop
+L3:
+L4:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual System.Boolean System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::MoveNext()
+brtrue.s L5
+leave.s L6
+[EX_BeginFinally]
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+constrained. System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster]
+callvirt abstract virtual System.Void System.IDisposable::Dispose()
+[EX_EndException]
+endfinally
+L6:
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+callvirt System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster> System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::GetEnumerator()
+stloc.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+[EX_BeginException]
+br.s L7
+L9:
+ldloca.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::get_Current()
+stloc.s 6 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 6 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L8
+ldloc.2
+ldloc.s 6 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Int64 Sandbox.Game.Entities.MyDataBroadcaster::get_AntennaEntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Add(System.Int64 item)
+pop
+L7:
+L8:
+ldloca.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual System.Boolean System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::MoveNext()
+brtrue.s L9
+leave.s L10
+[EX_BeginFinally]
+ldloca.s 5 (System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+constrained. System.Collections.Generic.List`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster]
+callvirt abstract virtual System.Void System.IDisposable::Dispose()
+[EX_EndException]
+endfinally
+L10:
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+callvirt virtual System.Int32 System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::get_Count()
+ldc.i4.1
+sub
+stloc.s 7 (System.Int32)
+br.s L11
+L16:
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+ldloc.s 7 (System.Int32)
+callvirt virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::get_Item(System.Int32 index)
+stloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L12
+ldloc.2
+ldloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+callvirt abstract virtual System.Int64 VRage.ModAPI.IMyEntity::get_EntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Contains(System.Int64 item)
+brtrue.s L13
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+ldloc.s 7 (System.Int32)
+call static System.Void System.Collections.Generic.ListExtensions::RemoveAtFast(System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> list, System.Int32 index)
+ldarg.0
+ldfld Sandbox.Game.Entities.BroadcasterChangeInfo Sandbox.Game.Entities.MyDataReceiver::OnBroadcasterLost
+dup
+brtrue.s L14
+pop
+br.s L15
+L14:
+ldloc.s 8 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt virtual System.Void Sandbox.Game.Entities.BroadcasterChangeInfo::Invoke(Sandbox.Game.Entities.MyDataBroadcaster broadcaster)
+L12:
+L13:
+L15:
+ldloc.s 7 (System.Int32)
+ldc.i4.1
+sub
+stloc.s 7 (System.Int32)
+L11:
+ldloc.s 7 (System.Int32)
+ldc.i4.0
+bge.s L16
+ldarg.0
+ldfld System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_broadcastersInRange
+callvirt System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster> System.Collections.Generic.HashSet`1<Sandbox.Game.Entities.MyDataBroadcaster>::GetEnumerator()
+stloc.3
+[EX_BeginException]
+br.s L17
+L22:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual Sandbox.Game.Entities.MyDataBroadcaster System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::get_Current()
+stloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyEntityComponentBase::get_Entity()
+brfalse.s L18
+ldloc.2
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt System.Int64 Sandbox.Game.Entities.MyDataBroadcaster::get_AntennaEntityId()
+callvirt virtual System.Boolean System.Collections.Generic.HashSet`1<System.Int64>::Contains(System.Int64 item)
+brtrue.s L19
+ldarg.0
+ldfld System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster> Sandbox.Game.Entities.MyDataReceiver::m_lastBroadcastersInRange
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt virtual System.Void System.Collections.Generic.List`1<Sandbox.Game.Entities.MyDataBroadcaster>::Add(Sandbox.Game.Entities.MyDataBroadcaster item)
+ldarg.0
+ldfld Sandbox.Game.Entities.BroadcasterChangeInfo Sandbox.Game.Entities.MyDataReceiver::OnBroadcasterFound
+dup
+brtrue.s L20
+pop
+br.s L21
+L20:
+ldloc.s 9 (Sandbox.Game.Entities.MyDataBroadcaster)
+callvirt virtual System.Void Sandbox.Game.Entities.BroadcasterChangeInfo::Invoke(Sandbox.Game.Entities.MyDataBroadcaster broadcaster)
+L17:
+L18:
+L19:
+L21:
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+call virtual System.Boolean System.Collections.Generic.Enumerator<Sandbox.Game.Entities.MyDataBroadcaster>::MoveNext()
+brtrue.s L22
+leave.s L23
+[EX_BeginFinally]
+ldloca.s 3 (System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster])
+constrained. System.Collections.Generic.HashSet`1+Enumerator[Sandbox.Game.Entities.MyDataBroadcaster]
+callvirt abstract virtual System.Void System.IDisposable::Dispose()
+[EX_EndException]
+endfinally
+L23:
+ret

--- a/Shared/Patches/PatchHelpers.cs
+++ b/Shared/Patches/PatchHelpers.cs
@@ -15,16 +15,12 @@ namespace Shared.Patches
     {
         public static bool HarmonyPatchAll(IPluginLogger log, Harmony harmony)
         {
-#if DEBUG
-            Harmony.DEBUG = true;
-
-#if LIST_ALL_TYPES
+#if DEBUG && LIST_ALL_TYPES
             log.Info("All types:");
             foreach (var typ in AccessTools.AllTypes())
             {
                 log.Info(typ.FullName);
             }
-#endif
 #endif
 
             if (Common.Plugin.Config.DetectCodeChanges)
@@ -68,6 +64,7 @@ namespace Shared.Patches
         public static void Configure()
         {
             MySafeZonePatch.Configure();
+            MySessionComponentSafeZonesPatch.Configure();
             MyLargeTurretTargetingSystemPatch.Configure();
             MyPhysicsBodyPatch.Configure();
             HkShapePatch.Configure();
@@ -76,6 +73,9 @@ namespace Shared.Patches
             MyStorageExtensionsPatch.Configure();
             MyWindTurbinePatch.Configure();
             MyDefinitionIdToStringPatch.Configure();
+            MyCubeBlockPatch.Configure();
+            MyTerminalBlockPatch.Configure();
+            MyGridTerminalSystemPatch.Configure();
 
             // FIXME: Make this configurable!
             // PhysicsFixes.SetClusterSize(3000f);
@@ -91,20 +91,29 @@ namespace Shared.Patches
         public static void PatchUpdates()
         {
             MySafeZonePatch.Update();
+            MySessionComponentSafeZonesPatch.Update();
             MyLargeTurretTargetingSystemPatch.Update();
             MyWindTurbinePatch.Update();
             MyDefinitionIdToStringPatch.Update();
+            MyCubeBlockPatch.Update();
+            MyTerminalBlockPatch.Update();
+            MyGridTerminalSystemPatch.Update();
 
 #if DEBUG
             if (Common.Plugin.Tick % 1200 == 0)
             {
                 var log = Common.Plugin.Log;
                 log.Info("Cache hit rates:");
-                log.Info($"- MySafeZonePatch: {MySafeZonePatch.Report}");
+                log.Info($"- MySafeZonePatch IsSafe: {MySafeZonePatch.IsSafeCacheReport}");
+                log.Info($"- MySafeZonePatch IsActionAllowed: {MySafeZonePatch.IsActionAllowedCacheReport}");
+                log.Info($"- MySessionComponentSafeZonesPatch: {MySessionComponentSafeZonesPatch.CacheReport}");
                 log.Info($"- MyLargeTurretTargetingSystemPatch ArrayCache: {MyLargeTurretTargetingSystemPatch.ArrayCacheReport}");
                 log.Info($"- MyLargeTurretTargetingSystemPatch VisibilityCache: {MyLargeTurretTargetingSystemPatch.VisibilityCacheReport}");
                 log.Info($"- MyWindTurbinePatch: {MyWindTurbinePatch.CacheReport}");
                 log.Info($"- MyDefinitionIdToStringPatch: {MyDefinitionIdToStringPatch.CacheReport}");
+                log.Info($"- MyCubeBlockPatch: {MyCubeBlockPatch.CacheReport}");
+                log.Info($"- MyTerminalBlockPatch: {MyTerminalBlockPatch.CacheReport}");
+                log.Info($"- MyGridTerminalSystemPatch: {MyGridTerminalSystemPatch.InhibitorReport}");
             }
 #endif
         }

--- a/Shared/Patches/SafeZone/MySessionComponentSafeZonesPatch.cs
+++ b/Shared/Patches/SafeZone/MySessionComponentSafeZonesPatch.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Sandbox.Game.Entities;
+using Shared.Config;
+using Shared.Plugin;
+using Shared.Tools;
+using TorchPlugin.Shared.Tools;
+using VRage.Game.Entity;
+using VRage.Game.ObjectBuilders.Components;
+
+namespace Shared.Patches
+{
+    [HarmonyPatch(typeof(MySessionComponentSafeZones))]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    [SuppressMessage("ReSharper", "UnusedType.Global")]
+    public static class MySessionComponentSafeZonesPatch
+    {
+        private static IPluginConfig Config => Common.Config;
+        private static bool enabled;
+
+        public static void Configure()
+        {
+            enabled = Config.Enabled && Config.FixSafeAction;
+            Config.PropertyChanged += OnConfigChanged;
+        }
+
+        private static void OnConfigChanged(object sender, PropertyChangedEventArgs e)
+        {
+            enabled = Config.Enabled && Config.FixSafeAction;
+            if (!enabled)
+            {
+                Cache.Clear();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Update()
+        {
+            Cache.Cleanup();
+        }
+
+        private static readonly UintCache<long> Cache = new UintCache<long>(113 * 60, 128);
+
+#if DEBUG
+        public static string CacheReport => Cache.Report;
+#endif
+
+        [HarmonyPrefix]
+        [HarmonyPatch("IsActionAllowedForSafezone", typeof(MyEntity), typeof(MySafeZoneAction), typeof(long))]
+        [EnsureCode("a8373d73")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsActionAllowedForSafezonePrefix(MyEntity entity, MySafeZoneAction action, long sourceEntityId, ref bool __result, ref long __state)
+        {
+            if (!enabled)
+                return true;
+
+            if (entity == null)
+                return false;
+
+            var entityId = entity.EntityId;
+            var key = entityId ^ sourceEntityId ^ (long)action;
+            if (Cache.TryGetValue(key, out var value))
+            {
+                // In case of very rare key collision just run the original
+                value ^= (uint)entityId;
+                if (value > 1)
+                    return true;
+
+                __result = value != 0;
+                return false;
+            }
+
+            __state = key;
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("IsActionAllowedForSafezone", typeof(MyEntity), typeof(MySafeZoneAction), typeof(long))]
+        [EnsureCode("a8373d73")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void IsActionAllowedForSafezonePostfix(MyEntity entity, bool __result, long __state)
+        {
+            if (__state == 0)
+                return;
+
+            var entityIdLow32Bits = (uint)entity.EntityId;
+            Cache.Store(__state, (__result ? 1u : 0u) ^ entityIdLow32Bits, 120u + (entityIdLow32Bits & 15));
+        }
+    }
+}

--- a/Shared/Patches/ScriptCompiler/MyScriptCompilerPatch.cs
+++ b/Shared/Patches/ScriptCompiler/MyScriptCompilerPatch.cs
@@ -196,21 +196,13 @@ namespace Shared.Patches
                 using (var fileStream = File.OpenWrite(cachePath))
                     assemblyStream.CopyTo(fileStream);
             }
+            catch (IOException e)
+            {
+                Log.Warning("Failed to write compiled script assembly cache file: {0}; Error: {1}", cachePath, e.ToString());
+            }
             catch (Exception e)
             {
                 Log.Error(e, "Failed to write compiled script assembly cache file: {0}", cachePath);
-
-                if (File.Exists(cachePath))
-                {
-                    try
-                    {
-                        File.Delete(cachePath);
-                    }
-                    catch (Exception)
-                    {
-                        // Ignore
-                    }
-                }
             }
             finally
             {

--- a/Shared/Patches/TargetingSystem/MyLargeTurretTargetingSystemPatch.cs
+++ b/Shared/Patches/TargetingSystem/MyLargeTurretTargetingSystemPatch.cs
@@ -45,7 +45,7 @@ namespace Shared.Patches
             if (!enabled)
                 return;
 
-            VisibilityCache.Clean();
+            VisibilityCache.Cleanup();
         }
 
         // ReSharper disable once UnusedMember.Local
@@ -178,7 +178,7 @@ namespace Shared.Patches
             if (!VisibilityCache.TryGetValue(___m_targetReceiver.Entity.EntityId, out var cache))
                 return false;
 
-            cache.Clean();
+            cache.Cleanup();
             return false;
         }
 

--- a/Shared/Patches/TerminalSystem/MyGridTerminalSystemPatch.cs
+++ b/Shared/Patches/TerminalSystem/MyGridTerminalSystemPatch.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using Sandbox.Game.GameSystems;
+using Shared.Config;
+using Shared.Plugin;
+using Shared.Tools;
+using TorchPlugin.Shared.Tools;
+
+namespace Shared.Patches
+{
+    [HarmonyPatch(typeof(MyGridTerminalSystem))]
+    [SuppressMessage("ReSharper", "UnusedType.Global")]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    public static class MyGridTerminalSystemPatch
+    {
+        private static IPluginConfig Config => Common.Config;
+        private static bool enabled;
+
+        public static void Configure()
+        {
+            enabled = Config.Enabled && Config.FixTerminal; // !!!
+            Config.PropertyChanged += OnConfigChanged;
+        }
+
+        private static void OnConfigChanged(object sender, PropertyChangedEventArgs e)
+        {
+            enabled = Config.Enabled && Config.FixTerminal;
+            if (!enabled)
+                Inhibitor.Clear();
+        }
+
+        private static readonly UintCache<long> Inhibitor = new UintCache<long>(337 * 60);
+
+#if DEBUG
+        public static string InhibitorReport => Inhibitor.Report;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Update()
+        {
+            Inhibitor.Cleanup();
+        }
+
+        /* Called from MyProgrammableBlock.RunSandboxedProgramAction,
+        which can be frequent on multiplayer servers with PBs triggered a lot.
+        In this case the ownerID is the owner of the programmable block.
+        Since ownership changes rarely, frequent calls can be inhibited. */
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MyGridTerminalSystem.UpdateGridBlocksOwnership))]
+        [EnsureCode("98a58a26")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool UpdateGridBlocksOwnershipPrefix(MyGridTerminalSystem __instance, long ownerID)
+        {
+            if (!enabled)
+                return true;
+
+            var key = __instance.GetHashCode() ^ ownerID;
+            if (Inhibitor.TryGetValue(key, out var value))
+            {
+                // In the very rare case of key collision just let the call through
+                if (value != (uint)ownerID)
+                    return true;
+
+                // Inhibit repeated updates until the cache entry expires
+                return false;
+            }
+
+            // Inhibit subsequent calls after this one using cache entry expiration as a timer
+            Inhibitor.Store(key, (uint)ownerID, 4 * 60 + ((uint)key & 63));
+            return true;
+        }
+    }
+}

--- a/Shared/Patches/WindTurbine/MyWindTurbinePatch.cs
+++ b/Shared/Patches/WindTurbine/MyWindTurbinePatch.cs
@@ -44,7 +44,7 @@ namespace Shared.Patches
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Update()
         {
-            Cache.Clean();
+            Cache.Cleanup();
         }
 
         // ReSharper disable once UnusedMember.Local
@@ -78,7 +78,7 @@ namespace Shared.Patches
                 return;
 
             var entityId = __instance.EntityId;
-            Cache.Store(entityId, __result ? 1u : 0u, 900u + (uint)(entityId & 63));
+            Cache.Store(entityId, __result ? 1u : 0u, 30 * 60 + (uint)(entityId & 2047));
         }
     }
 }

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -9,8 +9,15 @@
     <Import_RootNamespace>Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\Block\MyCubeBlockPatch.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\Block\MyTerminalBlockPatch.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\Conveyor\MyPathfindingDataPatch.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\Memory\MyDataReceiverPatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\Memory\MyDefinitionIdToStringPatch.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\Memory\MyPlayerCollectionPatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\Physics\HkShapePatch.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\SafeZone\MySessionComponentSafeZonesPatch.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\TerminalSystem\MyGridTerminalSystemPatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\Turret\MyLargeTurretBasePatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\Cache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\CacheForever.cs" />
@@ -64,6 +71,8 @@
     <Content Include="$(MSBuildThisFileDirectory)Patches\Character\RigidBody_ContactPointCallback.patched.il" />
     <Content Include="$(MSBuildThisFileDirectory)Patches\Entity\InSceneGetter.original.il" />
     <Content Include="$(MSBuildThisFileDirectory)Patches\Entity\InSceneGetter.patched.il" />
+    <Content Include="$(MSBuildThisFileDirectory)Patches\Memory\UpdateBroadcastersInRange.original.il" />
+    <Content Include="$(MSBuildThisFileDirectory)Patches\Memory\UpdateBroadcastersInRange.patched.il" />
     <Content Include="$(MSBuildThisFileDirectory)Patches\Physics\HkShapeEquals.original.il" />
     <Content Include="$(MSBuildThisFileDirectory)Patches\Physics\HkShapeEquals.patched.il" />
     <Content Include="$(MSBuildThisFileDirectory)Patches\Physics\RigidBodyGetter.original.il" />

--- a/Shared/Tools/Cache.cs
+++ b/Shared/Tools/Cache.cs
@@ -57,7 +57,7 @@ namespace TorchPlugin.Shared.Tools
 
         // Must be called on every tick to to store the clock, but it does a cleanup only rarely
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Clean()
+        public void Cleanup()
         {
             if ((tick = Common.Plugin.Tick) < nextCleanup)
                 return;

--- a/Shared/Tools/RwLock.cs
+++ b/Shared/Tools/RwLock.cs
@@ -39,4 +39,43 @@ namespace Shared.Tools
             counter = 0;
         }
     }
+
+    public class RwLockCounter
+    {
+        private int counter;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquireForReading()
+        {
+            var spinWait = new SpinWait();
+            var previous = counter;
+            while (previous < 0 || previous != Interlocked.CompareExchange(ref counter, previous + 1, previous))
+            {
+                spinWait.SpinOnce();
+                previous = counter;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseAfterReading()
+        {
+            Interlocked.Decrement(ref counter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquireForWriting()
+        {
+            var spinWait = new SpinWait();
+            while (Interlocked.CompareExchange(ref counter, -1, 0) != 0)
+            {
+                spinWait.SpinOnce();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseAfterWriting()
+        {
+            counter = 0;
+        }
+    }
 }

--- a/Shared/Tools/UintCache.cs
+++ b/Shared/Tools/UintCache.cs
@@ -34,7 +34,7 @@ namespace TorchPlugin.Shared.Tools
 
         // Must be called on every tick to to store the clock, but it does a cleanup only rarely
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Clean()
+        public void Cleanup()
         {
             if ((tick = (ulong)Common.Plugin.Tick << 32) < nextCleanup)
                 return;

--- a/TorchPlugin/Commands.cs
+++ b/TorchPlugin/Commands.cs
@@ -37,6 +37,11 @@ namespace TorchPlugin
             Respond($"character: {Format(config.FixCharacter)}");
             Respond($"memory: {Format(config.FixMemory)}");
             Respond($"endshoot: {Format(config.FixEndShoot)}");
+            Respond($"access: {Format(config.FixAccess)}");
+            Respond($"broadcast: {Format(config.FixBroadcast)}");
+            Respond($"block_limit: {Format(config.FixBlockLimit)}");
+            Respond($"safe_action: {Format(config.FixSafeAction)}");
+            Respond($"terminal: {Format(config.FixTerminal)}");
             //BOOL_OPTION Respond($"option_name: {Format(config.OptionName)}");
         }
 
@@ -178,6 +183,26 @@ namespace TorchPlugin
                     Config.FixEndShoot = parsedFlag;
                     break;
 
+                case "access":
+                    Config.FixAccess = parsedFlag;
+                    break;
+
+                case "broadcast":
+                    Config.FixBroadcast = parsedFlag;
+                    break;
+
+                case "block_limit":
+                    Config.FixBlockLimit = parsedFlag;
+                    break;
+
+                case "safe_action":
+                    Config.FixSafeAction = parsedFlag;
+                    break;
+
+                case "terminal":
+                    Config.FixTerminal = parsedFlag;
+                    break;
+
                 /*BOOL_OPTION
                 case "option_name":
                     Config.OptionName = parsedFlag;
@@ -205,6 +230,11 @@ namespace TorchPlugin
                     Respond("  character");
                     Respond("  memory");
                     Respond("  endshoot");
+                    Respond("  access");
+                    Respond("  broadcast");
+                    Respond("  block_limit");
+                    Respond("  safe_action");
+                    Respond("  terminal");
                     //BOOL_OPTION Respond("  option_name");
                     return;
             }

--- a/TorchPlugin/ConfigView.xaml
+++ b/TorchPlugin/ConfigView.xaml
@@ -70,6 +70,31 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <!--BOOL_OPTION
             <RowDefinition Height="Auto" />
             BOOL_OPTION-->
@@ -130,43 +155,63 @@
         <CheckBox Grid.Row="18" Grid.Column="0" Name="FixEndShoot" IsChecked="{Binding FixEndShoot}" Margin="5"/>
         <TextBlock Grid.Row="18" Grid.Column="1" Text="Adds a missing call to EndShoot on server side, fixing subsequent issues on client side" VerticalAlignment="Center" Margin="5"/>
 
+        <CheckBox Grid.Row="19" Grid.Column="0" Name="FixAccess" IsChecked="{Binding FixAccess}" Margin="5"/>
+        <TextBlock Grid.Row="19" Grid.Column="1" Text="Caches the result of MyCubeBlock.GetUserRelationToOwner and MyTerminalBlock.HasPlayerAccessReason" VerticalAlignment="Center" Margin="5"/>
+
+        <CheckBox Grid.Row="20" Grid.Column="0" Name="FixBroadcast" IsChecked="{Binding FixBroadcast}" Margin="5"/>
+        <TextBlock Grid.Row="20" Grid.Column="1" Text="Reduces memory allocations in MyDataReceiver.UpdateBroadcastersInRange (needs restart)" VerticalAlignment="Center" Margin="5"/>
+
+        <CheckBox Grid.Row="21" Grid.Column="0" Name="FixBlockLimit" IsChecked="{Binding FixBlockLimit}" Margin="5"/>
+        <TextBlock Grid.Row="21" Grid.Column="1" Text="Suppresses frequent calls to MyPlayerCollection.SendDirtyBlockLimits" VerticalAlignment="Center" Margin="5"/>
+
+        <CheckBox Grid.Row="22" Grid.Column="0" Name="FixSafeAction" IsChecked="{Binding FixSafeAction}" Margin="5"/>
+        <TextBlock Grid.Row="22" Grid.Column="1" Text="Caches the result of MySafeZone.IsActionAllowed and MySessionComponentSafeZones.IsActionAllowedForSafezone for 2 seconds" VerticalAlignment="Center" Margin="5"/>
+
+        <CheckBox Grid.Row="23" Grid.Column="0" Name="FixTerminal" IsChecked="{Binding FixTerminal}" Margin="5"/>
+        <TextBlock Grid.Row="23" Grid.Column="1" Text="Suppresses frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership updating IsAccessibleForProgrammableBlock unnecessarily often" VerticalAlignment="Center" Margin="5"/>
+
         <!--BOOL_OPTION
-        <CheckBox Grid.Row="19" Grid.Column="0" Name="OptionName" IsChecked="{Binding OptionName}" Margin="5"/>
-        <TextBlock Grid.Row="19" Grid.Column="1" Text="Option tooltip" VerticalAlignment="Center" Margin="5"/>
+        <CheckBox Grid.Row="24" Grid.Column="0" Name="OptionName" IsChecked="{Binding OptionName}" Margin="5"/>
+        <TextBlock Grid.Row="24" Grid.Column="1" Text="Option tooltip" VerticalAlignment="Center" Margin="5"/>
 
         BOOL_OPTION-->
-        <TextBlock Grid.Row="20" Grid.Column="0" Grid.ColumnSpan="2" Text="Configuration changes are saved automatically. It is safe to change them while the game is running." VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" Text="Admin commands:" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="22" Grid.Column="1" Text="!help pfi" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="23" Grid.Column="1" Text="!pfi info" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="24" Grid.Column="1" Text="!pfi fix name bool" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="30" Grid.Column="0" Grid.ColumnSpan="2" Text="Configuration changes are saved automatically. It is safe to change them while the game is running." VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="31" Grid.Column="0" Grid.ColumnSpan="2" Text="Admin commands:" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="32" Grid.Column="1" Text="!help pfi" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="33" Grid.Column="1" Text="!pfi info" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="34" Grid.Column="1" Text="!pfi fix name bool" VerticalAlignment="Center" Margin="5" />
 
-        <TextBlock Grid.Row="25" Grid.Column="0" Grid.ColumnSpan="2" Text="Available names:" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="26" Grid.Column="1" Text="grid_merge" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="27" Grid.Column="1" Text="grid_paste" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="28" Grid.Column="1" Text="p2p_stats" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="29" Grid.Column="1" Text="gc" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="30" Grid.Column="1" Text="api_stats" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="31" Grid.Column="1" Text="grid_groups" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="32" Grid.Column="1" Text="grid_groups" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="33" Grid.Column="1" Text="cache_mods" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="34" Grid.Column="1" Text="cache_scripts" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="35" Grid.Column="1" Text="safe_zone" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="36" Grid.Column="1" Text="targeting" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="37" Grid.Column="1" Text="wind_turbine" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="38" Grid.Column="1" Text="voxel" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="39" Grid.Column="1" Text="physics" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="40" Grid.Column="1" Text="entity" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="41" Grid.Column="1" Text="character" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="42" Grid.Column="1" Text="memory" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="43" Grid.Column="1" Text="endshoot" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="35" Grid.Column="0" Grid.ColumnSpan="2" Text="Available names:" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="36" Grid.Column="1" Text="grid_merge" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="37" Grid.Column="1" Text="grid_paste" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="38" Grid.Column="1" Text="p2p_stats" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="39" Grid.Column="1" Text="gc" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="40" Grid.Column="1" Text="api_stats" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="41" Grid.Column="1" Text="grid_groups" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="42" Grid.Column="1" Text="grid_groups" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="43" Grid.Column="1" Text="cache_mods" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="44" Grid.Column="1" Text="cache_scripts" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="45" Grid.Column="1" Text="safe_zone" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="46" Grid.Column="1" Text="targeting" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="47" Grid.Column="1" Text="wind_turbine" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="48" Grid.Column="1" Text="voxel" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="49" Grid.Column="1" Text="physics" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="50" Grid.Column="1" Text="entity" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="51" Grid.Column="1" Text="character" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="52" Grid.Column="1" Text="memory" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="53" Grid.Column="1" Text="endshoot" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="54" Grid.Column="1" Text="access" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="55" Grid.Column="1" Text="broadcast" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="56" Grid.Column="1" Text="block_limit" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="57" Grid.Column="1" Text="safe_action" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="58" Grid.Column="1" Text="terminal" VerticalAlignment="Center" Margin="5" />
         <!--BOOL_OPTION
-        <TextBlock Grid.Row="44" Grid.Column="1" Text="option_name" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="59" Grid.Column="1" Text="option_name" VerticalAlignment="Center" Margin="5" />
         BOOL_OPTION-->
 
-        <TextBlock Grid.Row="50" Grid.Column="0" Grid.ColumnSpan="2" Text="Accepted bool values:" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="51" Grid.Column="1" Text="False: 0 off no n false f" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="52" Grid.Column="1" Text="True: 1 on yes y false f" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="70" Grid.Column="0" Grid.ColumnSpan="2" Text="Accepted bool values:" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="71" Grid.Column="1" Text="False: 0 off no n false f" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="72" Grid.Column="1" Text="True: 1 on yes y false f" VerticalAlignment="Center" Margin="5" />
 
     </Grid>
 </UserControl>

--- a/TorchPlugin/PluginConfig.cs
+++ b/TorchPlugin/PluginConfig.cs
@@ -27,6 +27,11 @@ namespace TorchPlugin
         private bool fixCharacter = true;
         private bool fixMemory = true;
         private bool fixEndShoot = true;
+        private bool fixAccess = false;
+        private bool fixBroadcast = false;
+        private bool fixBlockLimit = false;
+        private bool fixSafeAction = false;
+        private bool fixTerminal = false;
         //BOOL_OPTION private bool optionName = false;
 
         [Display(Order = 1, GroupName = "General", Name = "Enable plugin", Description = "Enable the plugin (all fixes)")]
@@ -160,6 +165,41 @@ namespace TorchPlugin
         {
             get => fixEndShoot;
             set => SetValue(ref fixEndShoot, value);
+        }
+
+        [Display(Order = 19, GroupName = "Fixes", Name = "Less frequent update of block access rights", Description = "Caches the result of MyCubeBlock.GetUserRelationToOwner and MyTerminalBlock.HasPlayerAccessReason")]
+        public bool FixAccess
+        {
+            get => fixAccess;
+            set => SetValue(ref fixAccess, value);
+        }
+
+        [Display(Order = 19, GroupName = "Fixes", Name = "Reduced memory allocation in broadcaster scanning", Description = "Reduces memory allocations in MyDataReceiver.UpdateBroadcastersInRange (needs restart)")]
+        public bool FixBroadcast
+        {
+            get => fixBroadcast;
+            set => SetValue(ref fixBroadcast, value);
+        }
+
+        [Display(Order = 19, GroupName = "Fixes", Name = "Less frequent sync of block counts for limit checking", Description = "Suppresses frequent calls to MyPlayerCollection.SendDirtyBlockLimits")]
+        public bool FixBlockLimit
+        {
+            get => fixBlockLimit;
+            set => SetValue(ref fixBlockLimit, value);
+        }
+
+        [Display(Order = 19, GroupName = "Fixes", Name = "Cache actions allowed by the safe zone", Description = "Caches the result of MySafeZone.IsActionAllowed and MySessionComponentSafeZones.IsActionAllowedForSafezone for 2 seconds")]
+        public bool FixSafeAction
+        {
+            get => fixSafeAction;
+            set => SetValue(ref fixSafeAction, value);
+        }
+
+        [Display(Order = 19, GroupName = "Fixes", Name = "Less frequent update of PB access to blocks", Description = "Suppresses frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership updating IsAccessibleForProgrammableBlock unnecessarily often")]
+        public bool FixTerminal
+        {
+            get => fixTerminal;
+            set => SetValue(ref fixTerminal, value);
         }
 
         /*BOOL_OPTION

--- a/TorchPlugin/Properties/AssemblyInfo.cs
+++ b/TorchPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.2.0")]
-[assembly: AssemblyFileVersion("1.9.2.0")]
+[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyFileVersion("1.10.0.0")]

--- a/TorchPlugin/manifest.xml
+++ b/TorchPlugin/manifest.xml
@@ -3,5 +3,5 @@
   <Name>PerformanceImprovements</Name>
   <Guid>c2cf3ed2-c6ac-4dbd-ab9a-613a1ef67784</Guid>
   <Repository>PerformanceImprovements</Repository>
-  <Version>v1.9.2.0</Version>
+  <Version>v1.10.0.0</Version>
 </PluginManifest>


### PR DESCRIPTION
- MyCubeBlock.GetUserRelationToOwner fix
- MyPathfindingData.Timestamp getter and setter fix
- MySafeZone.IsOutside fix
- Caching MySafeZone.IsActionAllowed result
- Reducing frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership
- Caching MyTerminalBlock.HasPlayerAccessReason
- Reduced memory allocations in MyDataReceiver.UpdateBroadcastersInRange
- Calling MyPlayerCollection.SendDirtyBlockLimits less frequently
- Disabled MyDefinitionIdToString result verification in DEBUG mode
- Fixed another race condition with exception log in the script compiler
- No global Harmony debug log file, use [HarmonyDebug] instead