### PR TITLE
1.10.9

### DIFF
--- a/ClientPlugin/ClientPlugin.csproj
+++ b/ClientPlugin/ClientPlugin.csproj
@@ -19,7 +19,7 @@
         <DebugType>full</DebugType>
         <Optimize>false</Optimize>
         <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <DefineConstants>CLIENT;DEBUG;TRACE</DefineConstants>
         <ErrorReport>prompt</ErrorReport>
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
@@ -28,7 +28,7 @@
         <DebugType>pdbonly</DebugType>
         <Optimize>true</Optimize>
         <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
+        <DefineConstants>CLIENT;TRACE</DefineConstants>
         <ErrorReport>prompt</ErrorReport>
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>

--- a/ClientPlugin/GUI/PluginConfigDialog.cs
+++ b/ClientPlugin/GUI/PluginConfigDialog.cs
@@ -123,7 +123,13 @@ namespace ClientPlugin.GUI
             CreateCheckbox(out fixP2PUpdateStatsLabel, out fixP2PUpdateStatsCheckbox, config.FixP2PUpdateStats, value => config.FixP2PUpdateStats = value, "Fix P2P update stats", "Eliminate 98% of EOS P2P network statistics updates (VRage.EOS.MyP2PQoSAdapter.UpdateStats)");
             CreateCheckbox(out fixGarbageCollectionLabel, out fixGarbageCollectionCheckbox, config.FixGarbageCollection, value => config.FixGarbageCollection = value, "Fix garbage collection", "Eliminate long pauses on starting and stopping large worlds by disabling selected GC.Collect calls");
             CreateCheckbox(out fixGridGroupsLabel, out fixGridGroupsCheckbox, config.FixGridGroups, value => config.FixGridGroups = value, "Fix grid groups", "Disable resource updates while grids are being moved between groups");
-            CreateCheckbox(out cacheModsLabel, out cacheModsCheckbox, config.CacheMods, value => config.CacheMods = value, "Cache compiled mods", "Caches compiled mods for faster world load");
+
+            // 1.10.9 (2023-07-30): Disabled mod compilation on client
+            // as per request of avaness. Reason:
+            // "Plugin loader added compilation symbols to mods, so it breaks
+            //  build info in really weird ways because it uses that symbol"
+            CreateCheckbox(out cacheModsLabel, out cacheModsCheckbox, false, value => config.CacheMods = value, "Cache compiled mods", "Caches compiled mods for faster world load" + "\n\n1.10.9 (2023-07-30): Disabled mod compilation on client\nas per request of avaness. Reason:\n\"Plugin loader added compilation symbols to mods, so it breaks\nbuild info in really weird ways because it uses that symbol.\"", false);
+
             CreateCheckbox(out cacheScriptsLabel, out cacheScriptsCheckbox, config.CacheScripts, value => config.CacheScripts = value, "Cache compiled scripts", "Caches compiled in-game scripts (PB programs) to reduce lag");
             CreateCheckbox(out disableModApiStatisticsLabel, out disableModApiStatisticsCheckbox, config.DisableModApiStatistics, value => config.DisableModApiStatistics = value, "Disable Mod API statistics", "Disable the collection of Mod API call statistics to eliminate the overhead (affects only world loading)");
             CreateCheckbox(out fixSafeZoneLabel, out fixSafeZoneCheckbox, config.FixSafeZone, value => config.FixSafeZone = value, "Fix safe zone lag", "Caches frequent recalculations in safe zones");
@@ -158,21 +164,30 @@ namespace ClientPlugin.GUI
 
         private void OnOk(MyGuiControlButton _) => CloseScreen();
 
-        private void CreateCheckbox(out MyGuiControlLabel labelControl, out MyGuiControlCheckbox checkboxControl, bool value, Action<bool> store, string label, string tooltip)
+        private void CreateCheckbox(out MyGuiControlLabel labelControl, out MyGuiControlCheckbox checkboxControl, bool value, Action<bool> store, string label, string tooltip, bool enabled = true)
         {
             labelControl = new MyGuiControlLabel
             {
                 Text = label,
-                OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP
+                OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP,
+                Enabled = enabled,
             };
 
             checkboxControl = new MyGuiControlCheckbox(toolTip: tooltip)
             {
                 OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP,
-                Enabled = true,
-                IsChecked = value
+                IsChecked = value,
+                Enabled = enabled,
+                CanHaveFocus = enabled
             };
-            checkboxControl.IsCheckedChanged += cb => store(cb.IsChecked);
+            if (enabled)
+            {
+                checkboxControl.IsCheckedChanged += cb => store(cb.IsChecked);
+            }
+            else
+            {
+                checkboxControl.IsCheckedChanged += cb => { cb.IsChecked = value; };
+            }
         }
 
         private void EnableDisableFixes(MyGuiControlCheckbox _ = null)

--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.10.8.0")]
-[assembly: AssemblyFileVersion("1.10.8.0")]
+[assembly: AssemblyVersion("1.10.9.0")]
+[assembly: AssemblyFileVersion("1.10.9.0")]

--- a/DedicatedPlugin/Properties/AssemblyInfo.cs
+++ b/DedicatedPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.10.8.0")]
-[assembly: AssemblyFileVersion("1.10.8.0")]
+[assembly: AssemblyVersion("1.10.9.0")]
+[assembly: AssemblyFileVersion("1.10.9.0")]

--- a/Shared/Patches/ScriptCompiler/MyScriptCompilerPatch.cs
+++ b/Shared/Patches/ScriptCompiler/MyScriptCompilerPatch.cs
@@ -214,6 +214,13 @@ namespace Shared.Patches
         {
             if (!Config.Enabled ||
                 target == MyApiTarget.None ||
+#if CLIENT
+                // 1.10.9 (2023-07-30): Disabled mod compilation on client
+                // as per request of avaness. Reason:
+                // "Plugin loader added compilation symbols to mods, so it breaks
+                //  build info in really weird ways because it uses that symbol"
+                target == MyApiTarget.Mod ||
+#endif
                 target == MyApiTarget.Ingame && !Config.CacheScripts ||
                 target == MyApiTarget.Mod && !Config.CacheMods)
             {

--- a/TorchPlugin/Properties/AssemblyInfo.cs
+++ b/TorchPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.10.8.0")]
-[assembly: AssemblyFileVersion("1.10.8.0")]
+[assembly: AssemblyVersion("1.10.9.0")]
+[assembly: AssemblyFileVersion("1.10.9.0")]

--- a/TorchPlugin/manifest.xml
+++ b/TorchPlugin/manifest.xml
@@ -3,5 +3,5 @@
   <Name>PerformanceImprovements</Name>
   <Guid>c2cf3ed2-c6ac-4dbd-ab9a-613a1ef67784</Guid>
   <Repository>PerformanceImprovements</Repository>
-  <Version>v1.10.8.0</Version>
+  <Version>v1.10.9.0</Version>
 </PluginManifest>


### PR DESCRIPTION
Disabled mod compilation on client as per request of avaness.

Reason: "Plugin loader added compilation symbols to mods, so it breaks build info in really weird ways because it uses that symbol"