### PR TITLE
1.11.2

### DIFF
--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.1.0")]
-[assembly: AssemblyFileVersion("1.11.1.0")]
+[assembly: AssemblyVersion("1.11.2.0")]
+[assembly: AssemblyFileVersion("1.11.2.0")]

--- a/DedicatedPlugin/Properties/AssemblyInfo.cs
+++ b/DedicatedPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.1.0")]
-[assembly: AssemblyFileVersion("1.11.1.0")]
+[assembly: AssemblyVersion("1.11.2.0")]
+[assembly: AssemblyFileVersion("1.11.2.0")]

--- a/Shared/Patches/Conveyor/MyGridConveyorSystemPatch.cs
+++ b/Shared/Patches/Conveyor/MyGridConveyorSystemPatch.cs
@@ -120,7 +120,12 @@ namespace Shared.Patches
             if (cache == null)
             {
                 ReachableCaches.BeginWriting();
-                ReachableCaches[group] = cache = CreateCache();
+                cache = ReachableCaches.GetValueOrDefault(group);
+                if (cache == null)
+                {
+                    cache = CreateCache();
+                    ReachableCaches[group] = cache;
+                }
                 ReachableCaches.FinishWriting();
             }
 

--- a/TorchPlugin/Properties/AssemblyInfo.cs
+++ b/TorchPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.1.0")]
-[assembly: AssemblyFileVersion("1.11.1.0")]
+[assembly: AssemblyVersion("1.11.2.0")]
+[assembly: AssemblyFileVersion("1.11.2.0")]

--- a/TorchPlugin/manifest.xml
+++ b/TorchPlugin/manifest.xml
@@ -3,5 +3,5 @@
   <Name>PerformanceImprovements</Name>
   <Guid>c2cf3ed2-c6ac-4dbd-ab9a-613a1ef67784</Guid>
   <Repository>PerformanceImprovements</Repository>
-  <Version>v1.11.1.0</Version>
+  <Version>v1.11.2.0</Version>
 </PluginManifest>


### PR DESCRIPTION
- Fixed potential crash in conveyor Reachable cache logic

It seemed to be a race condition which I could not reproduce, but found in the code. Since I could not verify the fix an error handler is added to silently log any such exception and just call the original method instead. This way the server won't crash and the result will also be correct.