### PR TITLE
1.11.4

### DIFF
--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.3.0")]
-[assembly: AssemblyFileVersion("1.11.3.0")]
+[assembly: AssemblyVersion("1.11.4.0")]
+[assembly: AssemblyFileVersion("1.11.4.0")]

--- a/CodeGenerator.py
+++ b/CodeGenerator.py
@@ -135,6 +135,7 @@ def main():
     # generate_bool_option('FixTerminal', 'terminal', 'Less frequent update of PB access to blocks', 'Suppresses frequent calls to MyGridTerminalSystem.UpdateGridBlocksOwnership updating IsAccessibleForProgrammableBlock unnecessarily often')
     # generate_bool_option('FixTextPanel', 'text_panel', 'Text panel performance fixes', 'Disables UpdateVisibility of LCD surfaces on multiplayer servers')
     # generate_bool_option('FixConveyor', 'conveyor', 'Conveyor network performance fixes', 'Caches conveyor network lookups')
+    # generate_bool_option('FixWheelTrail', 'wheel_trail', 'Disable the tracking of wheel trails on server', 'Disable the tracking of wheel trails on server, where they are not needed at all (trails are only visual elements)')
 
 
 if __name__ == '__main__':

--- a/DedicatedPlugin/Properties/AssemblyInfo.cs
+++ b/DedicatedPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.3.0")]
-[assembly: AssemblyFileVersion("1.11.3.0")]
+[assembly: AssemblyVersion("1.11.4.0")]
+[assembly: AssemblyFileVersion("1.11.4.0")]

--- a/Shared/Config/IPluginConfig.cs
+++ b/Shared/Config/IPluginConfig.cs
@@ -76,6 +76,9 @@ namespace Shared.Config
         // Rate limited excessive logging from MyDefinitionManager.GetBlueprintDefinition
         bool FixLogFlooding { get; set; }
 
+        // Disable the tracking of wheel trails on server, where they are not needed at all (trails are only visual elements)
+        bool FixWheelTrail { get; set; }
+
         /*BOOL_OPTION
         // Option tooltip
         bool OptionName { get; set; }

--- a/Shared/Config/PluginConfig.cs
+++ b/Shared/Config/PluginConfig.cs
@@ -53,6 +53,7 @@ namespace Shared.Config
         private bool fixTextPanel = true;
         private bool fixConveyor = true;
         private bool fixLogFlooding = true;
+        private bool fixWheelTrail = true;
         //BOOL_OPTION private bool optionName = true;
 
         public bool Enabled
@@ -197,6 +198,12 @@ namespace Shared.Config
         {
             get => fixLogFlooding;
             set => SetValue(ref fixLogFlooding, value);
+        }
+
+        public bool FixWheelTrail
+        {
+            get => fixWheelTrail;
+            set => SetValue(ref fixWheelTrail, value);
         }
 
         /*BOOL_OPTION

--- a/Shared/Patches/Conveyor/MyPathfindingDataPatch.cs
+++ b/Shared/Patches/Conveyor/MyPathfindingDataPatch.cs
@@ -9,7 +9,7 @@ using HarmonyLib;
 using Shared.Tools;
 using VRage.Algorithms;
 
-namespace Shared.Patches.Conveyor
+namespace Shared.Patches
 {
     [HarmonyPatch(typeof(MyPathfindingData))]
     [SuppressMessage("ReSharper", "InconsistentNaming")]

--- a/Shared/Patches/TextPanel/MyLcdSurfaceComponentPatch.cs
+++ b/Shared/Patches/TextPanel/MyLcdSurfaceComponentPatch.cs
@@ -8,7 +8,7 @@ using Shared.Plugin;
 using Shared.Tools;
 using SpaceEngineers.Game.EntityComponents.Blocks;
 
-namespace Shared.Patches.TextPanel
+namespace Shared.Patches
 {
     [SuppressMessage("ReSharper", "UnusedType.Global")]
     [SuppressMessage("ReSharper", "UnusedMember.Local")]

--- a/Shared/Patches/Wheel/MyWheelPatch.cs
+++ b/Shared/Patches/Wheel/MyWheelPatch.cs
@@ -1,0 +1,33 @@
+﻿#if TORCH || DEDICATED
+
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using Sandbox.Game.Entities.Blocks;
+using Sandbox.Game.Multiplayer;
+using Shared.Config;
+using Shared.Plugin;
+using Shared.Tools;
+
+namespace Shared.Patches
+{
+    [SuppressMessage("ReSharper", "UnusedType.Global")]
+    [SuppressMessage("ReSharper", "UnusedMember.Local")]
+    [HarmonyPatch(typeof(MyWheel))]
+    public static class MyWheelPatch
+    {
+        private static IPluginConfig Config => Common.Config;
+
+        [HarmonyPrefix]
+        [HarmonyPatch("CheckTrail")]
+        [EnsureCode("b3d278e9")]
+        private static bool CheckTrailPrefix()
+        {
+            if (!Sync.IsDedicated)
+                return true;
+
+            return !Config.FixWheelTrail;
+        }
+    }
+}
+
+#endif

--- a/Shared/Shared.projitems
+++ b/Shared/Shared.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Patches\SafeZone\MySessionComponentSafeZonesPatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\TerminalSystem\MyGridTerminalSystemPatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Patches\TextPanel\MyLcdSurfaceComponentPatch.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Patches\Wheel\MyWheelPatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\Cache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\CacheStat.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\MySessionExtensions.cs" />

--- a/TorchPlugin/Commands.cs
+++ b/TorchPlugin/Commands.cs
@@ -57,6 +57,7 @@ namespace TorchPlugin
             Respond("  text_panel: Text panel performance fixes");
             Respond("  conveyor: Conveyor network performance fixes");
             Respond("  log_flooding: Rate limit logs with flooding potential");
+            Respond("  wheel_trail: Disable tracking of wheel trails on server");
             //BOOL_OPTION Respond("  option_name: Option label");
         }
 
@@ -85,6 +86,7 @@ namespace TorchPlugin
             Respond($"text_panel: {Format(config.FixTextPanel)}");
             Respond($"conveyor: {Format(config.FixConveyor)}");
             Respond($"log_flooding: {Format(config.FixLogFlooding)}");
+            Respond($"wheel_trail: {Format(config.FixWheelTrail)}");
             //BOOL_OPTION Respond($"option_name: {Format(config.OptionName)}");
         }
 
@@ -251,6 +253,10 @@ namespace TorchPlugin
 
                 case "log_flooding":
                     Config.FixLogFlooding = parsedFlag;
+                    break;
+
+                case "wheel_trail":
+                    Config.FixWheelTrail = parsedFlag;
                     break;
 
                 /*BOOL_OPTION

--- a/TorchPlugin/ConfigView.xaml
+++ b/TorchPlugin/ConfigView.xaml
@@ -98,6 +98,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <!--BOOL_OPTION
             <RowDefinition Height="Auto" />
             BOOL_OPTION-->
@@ -173,9 +174,12 @@
         <CheckBox Grid.Row="23" Grid.Column="0" Name="FixLogFlooding" IsChecked="{Binding FixLogFlooding}" Margin="5"/>
         <TextBlock Grid.Row="23" Grid.Column="1" Text="Rate limited excessive logging from MyDefinitionManager.GetBlueprintDefinition" VerticalAlignment="Center" Margin="5"/>
 
+        <CheckBox Grid.Row="24" Grid.Column="0" Name="FixWheelTrail" IsChecked="{Binding FixWheelTrail}" Margin="5"/>
+        <TextBlock Grid.Row="24" Grid.Column="1" Text="Disable tracking of wheel trails on server, where they are not needed at all (trails are only visual elements)" VerticalAlignment="Center" Margin="5"/>
+
         <!--BOOL_OPTION
-        <CheckBox Grid.Row="24" Grid.Column="0" Name="OptionName" IsChecked="{Binding OptionName}" Margin="5"/>
-        <TextBlock Grid.Row="24" Grid.Column="1" Text="Option tooltip" VerticalAlignment="Center" Margin="5"/>
+        <CheckBox Grid.Row="25" Grid.Column="0" Name="OptionName" IsChecked="{Binding OptionName}" Margin="5"/>
+        <TextBlock Grid.Row="25" Grid.Column="1" Text="Option tooltip" VerticalAlignment="Center" Margin="5"/>
 
         BOOL_OPTION-->
         <TextBlock Grid.Row="30" Grid.Column="0" Grid.ColumnSpan="2" Text="Configuration changes are saved automatically. It is safe to change them while the game is running." VerticalAlignment="Center" Margin="5" />
@@ -208,8 +212,9 @@
         <TextBlock Grid.Row="56" Grid.Column="1" Text="text_panel" VerticalAlignment="Center" Margin="5" />
         <TextBlock Grid.Row="57" Grid.Column="1" Text="conveyor" VerticalAlignment="Center" Margin="5" />
         <TextBlock Grid.Row="58" Grid.Column="1" Text="log_flooding" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="59" Grid.Column="1" Text="wheel_trail" VerticalAlignment="Center" Margin="5" />
         <!--BOOL_OPTION
-        <TextBlock Grid.Row="59" Grid.Column="1" Text="option_name" VerticalAlignment="Center" Margin="5" />
+        <TextBlock Grid.Row="60" Grid.Column="1" Text="option_name" VerticalAlignment="Center" Margin="5" />
         BOOL_OPTION-->
 
         <TextBlock Grid.Row="70" Grid.Column="0" Grid.ColumnSpan="2" Text="Valid bool values:" VerticalAlignment="Center" Margin="5" />

--- a/TorchPlugin/PluginConfig.cs
+++ b/TorchPlugin/PluginConfig.cs
@@ -32,6 +32,7 @@ namespace TorchPlugin
         private bool fixTextPanel = false;
         private bool fixConveyor = false;
         private bool fixLogFlooding = false;
+        private bool fixWheelTrail = false;
         //BOOL_OPTION private bool optionName = false;
 
         [Display(Order = 1, GroupName = "General", Name = "Enable plugin", Description = "Enable the plugin (all fixes)")]
@@ -202,8 +203,15 @@ namespace TorchPlugin
             set => SetValue(ref fixLogFlooding, value);
         }
 
+        [Display(Order = 27, GroupName = "Fixes", Name = "Disable tracking of wheel trails on server", Description = "Disable the tracking of wheel trails on server, where they are not needed at all (trails are only visual elements)")]
+        public bool FixWheelTrail
+        {
+            get => fixWheelTrail;
+            set => SetValue(ref fixWheelTrail, value);
+        }
+
         /*BOOL_OPTION
-        [Display(Order = 27, GroupName = "Fixes", Name = "Option label", Description = "Option tooltip")]
+        [Display(Order = 28, GroupName = "Fixes", Name = "Option label", Description = "Option tooltip")]
         public bool OptionName
         {
             get => optionName;

--- a/TorchPlugin/Properties/AssemblyInfo.cs
+++ b/TorchPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.3.0")]
-[assembly: AssemblyFileVersion("1.11.3.0")]
+[assembly: AssemblyVersion("1.11.4.0")]
+[assembly: AssemblyFileVersion("1.11.4.0")]

--- a/TorchPlugin/manifest.xml
+++ b/TorchPlugin/manifest.xml
@@ -3,5 +3,5 @@
   <Name>PerformanceImprovements</Name>
   <Guid>c2cf3ed2-c6ac-4dbd-ab9a-613a1ef67784</Guid>
   <Repository>PerformanceImprovements</Repository>
-  <Version>v1.11.3.0</Version>
+  <Version>v1.11.4.0</Version>
 </PluginManifest>


### PR DESCRIPTION
`FixWheelTrail`

Disable the tracking of wheel trails on server, where they are not needed at all. Tracking the wheel trails is useless on servers, because it is only used to render the trails (trails are only visual elements) with no consequence on game logic.

Patched method, only on Torch and DS: `MyWheel.CheckTrail`