### PR TITLE
1.11.8

### DIFF
--- a/ClientPlugin/ClientPlugin.csproj
+++ b/ClientPlugin/ClientPlugin.csproj
@@ -33,8 +33,8 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-          <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
+        <Reference Include="0Harmony, Version=2.3.3.0, Culture=neutral, processorArchitecture=MSIL">
+          <HintPath>..\packages\Lib.Harmony.2.3.3\lib\net48\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="DirectShowLib, Version=2.1.0.1599, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\Bin64\DirectShowLib.dll</HintPath>

--- a/ClientPlugin/GUI/PluginConfigDialog.cs
+++ b/ClientPlugin/GUI/PluginConfigDialog.cs
@@ -31,8 +31,10 @@ namespace ClientPlugin.GUI
         private MyGuiControlLabel fixGarbageCollectionLabel;
         private MyGuiControlCheckbox fixGarbageCollectionCheckbox;
 
+        /* Disabled due to inability to patch generics (methods of MyGroups)
         private MyGuiControlLabel fixGridGroupsLabel;
         private MyGuiControlCheckbox fixGridGroupsCheckbox;
+        */
 
         private MyGuiControlLabel cacheModsLabel;
         private MyGuiControlCheckbox cacheModsCheckbox;
@@ -131,7 +133,7 @@ namespace ClientPlugin.GUI
             CreateCheckbox(out fixGridPasteLabel, out fixGridPasteCheckbox, config.FixGridPaste, value => config.FixGridPaste = value, "Fix grid paste", "Disable updates during grid paste (MyCubeGrid.PasteBlocksServer)");
             CreateCheckbox(out fixP2PUpdateStatsLabel, out fixP2PUpdateStatsCheckbox, config.FixP2PUpdateStats, value => config.FixP2PUpdateStats = value, "Fix P2P update stats", "Eliminate 98% of EOS P2P network statistics updates (VRage.EOS.MyP2PQoSAdapter.UpdateStats)");
             CreateCheckbox(out fixGarbageCollectionLabel, out fixGarbageCollectionCheckbox, config.FixGarbageCollection, value => config.FixGarbageCollection = value, "Fix garbage collection", "Eliminate long pauses on starting and stopping large worlds by disabling selected GC.Collect calls");
-            CreateCheckbox(out fixGridGroupsLabel, out fixGridGroupsCheckbox, config.FixGridGroups, value => config.FixGridGroups = value, "Fix grid groups", "Disable resource updates while grids are being moved between groups");
+            // CreateCheckbox(out fixGridGroupsLabel, out fixGridGroupsCheckbox, config.FixGridGroups, value => config.FixGridGroups = value, "Fix grid groups", "Disable resource updates while grids are being moved between groups");
             CreateCheckbox(out cacheModsLabel, out cacheModsCheckbox, config.CacheMods, value => config.CacheMods = value, "Cache compiled mods", "Caches compiled mods for faster world load");
             CreateCheckbox(out cacheScriptsLabel, out cacheScriptsCheckbox, config.CacheScripts, value => config.CacheScripts = value, "Cache compiled scripts", "Caches compiled in-game scripts (PB programs) to reduce lag");
             CreateCheckbox(out disableModApiStatisticsLabel, out disableModApiStatisticsCheckbox, config.DisableModApiStatistics, value => config.DisableModApiStatistics = value, "Disable Mod API statistics", "Disable the collection of Mod API call statistics to eliminate the overhead (affects only world loading)");
@@ -203,7 +205,7 @@ namespace ClientPlugin.GUI
             fixGridPasteCheckbox.Enabled = enabled;
             fixP2PUpdateStatsCheckbox.Enabled = enabled;
             fixGarbageCollectionCheckbox.Enabled = enabled;
-            fixGridGroupsCheckbox.Enabled = enabled;
+            // fixGridGroupsCheckbox.Enabled = enabled;
             cacheModsCheckbox.Enabled = enabled;
             cacheScriptsCheckbox.Enabled = enabled;
             disableModApiStatisticsCheckbox.Enabled = enabled;
@@ -252,9 +254,11 @@ namespace ClientPlugin.GUI
             layoutTable.Add(fixGarbageCollectionLabel, MyAlignH.Left, MyAlignV.Center, row, 1);
             row++;
 
+            /* Disabled due to inability to patch generics (methods of MyGroups)
             layoutTable.Add(fixGridGroupsCheckbox, MyAlignH.Left, MyAlignV.Center, row, 0);
             layoutTable.Add(fixGridGroupsLabel, MyAlignH.Left, MyAlignV.Center, row, 1);
             row++;
+            */
 
             layoutTable.Add(cacheModsCheckbox, MyAlignH.Left, MyAlignV.Center, row, 0);
             layoutTable.Add(cacheModsLabel, MyAlignH.Left, MyAlignV.Center, row, 1);

--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.7.0")]
-[assembly: AssemblyFileVersion("1.11.7.0")]
+[assembly: AssemblyVersion("1.11.8.0")]
+[assembly: AssemblyFileVersion("1.11.8.0")]

--- a/ClientPlugin/packages.config
+++ b/ClientPlugin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.2.2" targetFramework="net48" />
+  <package id="Lib.Harmony" version="2.3.3" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net481" />
 </packages>

--- a/DedicatedPlugin/DedicatedPlugin.csproj
+++ b/DedicatedPlugin/DedicatedPlugin.csproj
@@ -33,8 +33,8 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-          <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
+        <Reference Include="0Harmony, Version=2.3.3.0, Culture=neutral, processorArchitecture=MSIL">
+          <HintPath>..\packages\Lib.Harmony.2.3.3\lib\net48\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="DirectShowLib, Version=2.1.0.1599, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\Torch\DedicatedServer64\DirectShowLib.dll</HintPath>

--- a/DedicatedPlugin/Properties/AssemblyInfo.cs
+++ b/DedicatedPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.7.0")]
-[assembly: AssemblyFileVersion("1.11.7.0")]
+[assembly: AssemblyVersion("1.11.8.0")]
+[assembly: AssemblyFileVersion("1.11.8.0")]

--- a/DedicatedPlugin/packages.config
+++ b/DedicatedPlugin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.2.2" targetFramework="net48" />
+  <package id="Lib.Harmony" version="2.3.3" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net481" />
 </packages>

--- a/Shared/Patches/Character/MyCharacterPatch.cs
+++ b/Shared/Patches/Character/MyCharacterPatch.cs
@@ -25,7 +25,7 @@ namespace Shared.Patches
         // ReSharper disable once UnusedMember.Local
         [HarmonyTranspiler]
         [HarmonyPatch("RigidBody_ContactPointCallback")]
-        [EnsureCode("230531d5|c1e4183d")]
+        [EnsureCode("c1e4183d")]
         private static IEnumerable<CodeInstruction> RigidBody_ContactPointCallbackTranspiler(IEnumerable<CodeInstruction> instructions)
         {
             if (!enabled)

--- a/Shared/Patches/Character/RigidBody_ContactPointCallback.original.il
+++ b/Shared/Patches/Character/RigidBody_ContactPointCallback.original.il
@@ -1,9 +1,9 @@
-// 230531d5
-newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::.ctor()
+// c1e4183d
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::.ctor()
 stloc.0
 ldloc.0
 ldarg.0
-stfld Sandbox.Game.Entities.Character.MyCharacter Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<>4__this
+stfld Sandbox.Game.Entities.Character.MyCharacter Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::<>4__this
 ldarg.0
 call System.Boolean Sandbox.Game.Entities.Character.MyCharacter::get_IsDead()
 brfalse.s L0
@@ -63,27 +63,27 @@ ldarg.0
 call static VRage.ModAPI.IMyEntity Sandbox.Engine.Physics.MyPhysicsExtensions::GetOtherEntity(Havok.HkContactPointEvent eventInfo, VRage.ModAPI.IMyEntity sourceEntity)
 callvirt abstract virtual VRage.Game.Components.MyPhysicsComponentBase VRage.ModAPI.IMyEntity::get_Physics()
 isinst Sandbox.Engine.Voxels.MyVoxelPhysicsBody
-stfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::otherPhysicsBody
+stfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::otherPhysicsBody
 ldloc.0
 ldarg.1
 ldfld Havok.HkContactPoint Havok.HkContactPointEvent::ContactPoint
 stloc.s 24 (Havok.HkContactPoint)
 ldloca.s 24 (Havok.HkContactPoint)
 call VRageMath.Vector3 Havok.HkContactPoint::get_Position()
-stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::contactPointPosition
+stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::contactPointPosition
 ldloc.0
 ldarg.1
 ldfld Havok.HkContactPoint Havok.HkContactPointEvent::ContactPoint
 stloc.s 24 (Havok.HkContactPoint)
 ldloca.s 24 (Havok.HkContactPoint)
 call VRageMath.Vector3 Havok.HkContactPoint::get_Normal()
-stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::contactPointNormal
+stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::contactPointNormal
 ldloc.0
-ldfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::otherPhysicsBody
+ldfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::otherPhysicsBody
 brfalse L8
 ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
 ldloc.0
-ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<RigidBody_ContactPointCallback>b__0()
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::<RigidBody_ContactPointCallback>b__0()
 newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
 ldstr "MyCharacter.RigidBody_ContactPointCallback.TrySpawnWalkingParticles"
 ldc.i4.m1
@@ -153,7 +153,7 @@ ldloc.0
 ldloc.3
 callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyPhysicsComponentBase::get_Entity()
 isinst VRage.Game.Entity.MyEntity
-stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 ldloc.1
 stloc.s 6 (Havok.HkRigidBody)
 ldarg.1
@@ -163,7 +163,7 @@ ldloca.s 24 (Havok.HkContactPoint)
 call VRageMath.Vector3 Havok.HkContactPoint::get_Normal()
 stloc.s 7 (VRageMath.Vector3)
 ldloc.0
-ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 ldarg.0
 bne.un.s L11
 ldc.i4.1
@@ -172,7 +172,7 @@ ldloc.0
 ldloc.s 4 (Sandbox.Engine.Physics.MyPhysicsBody)
 callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyPhysicsComponentBase::get_Entity()
 isinst VRage.Game.Entity.MyEntity
-stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 ldloc.2
 stloc.s 6 (Havok.HkRigidBody)
 ldloc.s 7 (VRageMath.Vector3)
@@ -180,7 +180,7 @@ call static VRageMath.Vector3 VRageMath.Vector3::op_UnaryNegation(VRageMath.Vect
 stloc.s 7 (VRageMath.Vector3)
 L11:
 ldloc.0
-ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 isinst Sandbox.Game.Entities.Character.MyCharacter
 stloc.s 8 (Sandbox.Game.Entities.Character.MyCharacter)
 ldloc.s 8 (Sandbox.Game.Entities.Character.MyCharacter)
@@ -213,7 +213,7 @@ L14:
 L16:
 L17:
 ldloc.0
-ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 isinst Sandbox.Game.Entities.MyCubeGrid
 stloc.s 9 (Sandbox.Game.Entities.MyCubeGrid)
 ldloc.s 9 (Sandbox.Game.Entities.MyCubeGrid)
@@ -383,15 +383,15 @@ ldarg.0
 ldfld System.Single Sandbox.Game.Entities.Character.MyCharacter::m_canPlayImpact
 ldc.r4 0
 bgt.un L38
-newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_1::.ctor()
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_1::.ctor()
 ldarg.0
 ldc.r4 0.3
 stfld System.Single Sandbox.Game.Entities.Character.MyCharacter::m_canPlayImpact
 dup
 ldarg.1
 ldobj Havok.HkContactPointEvent
-stfld Havok.HkContactPointEvent Sandbox.Game.Entities.Character.<>c__DisplayClass463_1::hkContactPointEvent
-ldftn System.Boolean Sandbox.Game.Entities.Character.<>c__DisplayClass463_1::<RigidBody_ContactPointCallback>b__1()
+stfld Havok.HkContactPointEvent Sandbox.Game.Entities.Character.<>c__DisplayClass469_1::hkContactPointEvent
+ldftn System.Boolean Sandbox.Game.Entities.Character.<>c__DisplayClass469_1::<RigidBody_ContactPointCallback>b__1()
 newobj System.Void System.Func`1<System.Boolean>::.ctor(System.Object object, System.IntPtr method)
 stloc.s 35 (System.Func`1[System.Boolean])
 ldarg.0
@@ -517,42 +517,42 @@ ldloc.s 19 (System.Single)
 mul
 ldc.r4 2
 div
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldloc.s 14 (System.Single)
 ldc.r4 2
 ble.un.s L48
 ldloc.0
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 400
 sub
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 br.s L49
 L48:
 ldloc.s 14 (System.Single)
 ldc.r4 0
 bne.un.s L50
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 100
 ble.un.s L51
 ldloc.0
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 80
 div
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 L49:
 L50:
 L51:
 ldloc.0
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 10
 div
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 1
 blt.un L52
 call static System.Boolean Sandbox.Game.Multiplayer.Sync::get_IsServer()
@@ -573,24 +573,56 @@ call static Sandbox.Engine.Physics.MyPhysicsBody Sandbox.Engine.Physics.MyPhysic
 callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyPhysicsComponentBase::get_Entity()
 stloc.s 39 (VRage.ModAPI.IMyEntity)
 L54:
-call static Sandbox.Game.World.MySession Sandbox.Game.World.MySession::get_Static()
-ldfld VRage.Game.MyObjectBuilder_SessionSettings Sandbox.Game.World.MySession::Settings
-ldfld System.Boolean VRage.Game.MyObjectBuilder_SessionSettings::EnableFriendlyFire
-brtrue.s L55
 ldloc.s 39 (VRage.ModAPI.IMyEntity)
 isinst Sandbox.Game.Weapons.MyMissile
 dup
 stloc.s 40 (Sandbox.Game.Weapons.MyMissile)
+brfalse L55
+call static Sandbox.Game.World.MySession Sandbox.Game.World.MySession::get_Static()
+ldfld VRage.Game.MyObjectBuilder_SessionSettings Sandbox.Game.World.MySession::Settings
+ldfld System.Boolean VRage.Game.MyObjectBuilder_SessionSettings::EnableFriendlyFire
 brfalse.s L56
 ldloc.s 40 (Sandbox.Game.Weapons.MyMissile)
 ldarg.0
 call Sandbox.Game.World.MyIdentity Sandbox.Game.Entities.Character.MyCharacter::GetIdentity()
 callvirt System.Int64 Sandbox.Game.World.MyIdentity::get_IdentityId()
 callvirt virtual System.Boolean Sandbox.Game.Weapons.MyMissile::IsCharacterIdFriendly(System.Int64 charId)
-brtrue.s L57
-ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
+brtrue L57
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::.ctor()
+stloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
+ldloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
 ldloc.0
-ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<RigidBody_ContactPointCallback>b__2()
+stfld Sandbox.Game.Entities.Character.<>c__DisplayClass469_0 Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::CS$<>8__locals1
+ldloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
+ldloc.s 40 (Sandbox.Game.Weapons.MyMissile)
+callvirt virtual VRage.Game.MyDefinitionBase Sandbox.Game.Weapons.MyMissile::get_AmmoDefinition()
+ldflda VRage.Game.MyDefinitionId VRage.Game.MyDefinitionBase::Id
+ldfld VRage.Utils.MyStringHash VRage.Game.MyDefinitionId::SubtypeId
+stfld VRage.Utils.MyStringHash Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::sn
+ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
+ldloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::<RigidBody_ContactPointCallback>b__3()
+newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
+ldstr "MyCharacter.DoDamage"
+ldc.i4.m1
+ldc.i4.0
+callvirt System.Void Sandbox.MySandboxGame::Invoke(System.Action action, System.String invokerName, System.Int32 startAtFrame, System.Int32 repeatTimes)
+ret
+L56:
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::.ctor()
+stloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldloc.0
+stfld Sandbox.Game.Entities.Character.<>c__DisplayClass469_0 Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::CS$<>8__locals2
+ldloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldloc.s 40 (Sandbox.Game.Weapons.MyMissile)
+callvirt virtual VRage.Game.MyDefinitionBase Sandbox.Game.Weapons.MyMissile::get_AmmoDefinition()
+ldflda VRage.Game.MyDefinitionId VRage.Game.MyDefinitionBase::Id
+ldfld VRage.Utils.MyStringHash VRage.Game.MyDefinitionId::SubtypeId
+stfld VRage.Utils.MyStringHash Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::sn
+ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
+ldloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::<RigidBody_ContactPointCallback>b__4()
 newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
 ldstr "MyCharacter.DoDamage"
 ldc.i4.m1
@@ -598,10 +630,9 @@ ldc.i4.0
 callvirt System.Void Sandbox.MySandboxGame::Invoke(System.Action action, System.String invokerName, System.Int32 startAtFrame, System.Int32 repeatTimes)
 ret
 L55:
-L56:
 ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
 ldloc.0
-ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<RigidBody_ContactPointCallback>b__3()
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::<RigidBody_ContactPointCallback>b__2()
 newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
 ldstr "MyCharacter.DoDamage"
 ldc.i4.m1

--- a/Shared/Patches/Character/RigidBody_ContactPointCallback.patched.il
+++ b/Shared/Patches/Character/RigidBody_ContactPointCallback.patched.il
@@ -1,9 +1,9 @@
-// 7b68e0c9
-newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::.ctor()
+// 94c97f4c
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::.ctor()
 stloc.0
 ldloc.0
 ldarg.0
-stfld Sandbox.Game.Entities.Character.MyCharacter Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<>4__this
+stfld Sandbox.Game.Entities.Character.MyCharacter Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::<>4__this
 ldarg.0
 call System.Boolean Sandbox.Game.Entities.Character.MyCharacter::get_IsDead()
 brfalse.s L0
@@ -63,29 +63,29 @@ ldarg.0
 call static VRage.ModAPI.IMyEntity Sandbox.Engine.Physics.MyPhysicsExtensions::GetOtherEntity(Havok.HkContactPointEvent eventInfo, VRage.ModAPI.IMyEntity sourceEntity)
 callvirt abstract virtual VRage.Game.Components.MyPhysicsComponentBase VRage.ModAPI.IMyEntity::get_Physics()
 isinst Sandbox.Engine.Voxels.MyVoxelPhysicsBody
-stfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::otherPhysicsBody
+stfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::otherPhysicsBody
 ldloc.0
 ldarg.1
 ldfld Havok.HkContactPoint Havok.HkContactPointEvent::ContactPoint
 stloc.s 24 (Havok.HkContactPoint)
 ldloca.s 24 (Havok.HkContactPoint)
 call VRageMath.Vector3 Havok.HkContactPoint::get_Position()
-stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::contactPointPosition
+stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::contactPointPosition
 ldloc.0
 ldarg.1
 ldfld Havok.HkContactPoint Havok.HkContactPointEvent::ContactPoint
 stloc.s 24 (Havok.HkContactPoint)
 ldloca.s 24 (Havok.HkContactPoint)
 call VRageMath.Vector3 Havok.HkContactPoint::get_Normal()
-stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::contactPointNormal
+stfld VRageMath.Vector3 Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::contactPointNormal
 call static System.Boolean Sandbox.Game.Multiplayer.Sync::get_IsDedicated()
 brtrue L8
 ldloc.0
-ldfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::otherPhysicsBody
+ldfld Sandbox.Engine.Voxels.MyVoxelPhysicsBody Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::otherPhysicsBody
 brfalse L8
 ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
 ldloc.0
-ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<RigidBody_ContactPointCallback>b__0()
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::<RigidBody_ContactPointCallback>b__0()
 newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
 ldstr "MyCharacter.RigidBody_ContactPointCallback.TrySpawnWalkingParticles"
 ldc.i4.m1
@@ -155,7 +155,7 @@ ldloc.0
 ldloc.3
 callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyPhysicsComponentBase::get_Entity()
 isinst VRage.Game.Entity.MyEntity
-stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 ldloc.1
 stloc.s 6 (Havok.HkRigidBody)
 ldarg.1
@@ -165,7 +165,7 @@ ldloca.s 24 (Havok.HkContactPoint)
 call VRageMath.Vector3 Havok.HkContactPoint::get_Normal()
 stloc.s 7 (VRageMath.Vector3)
 ldloc.0
-ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 ldarg.0
 bne.un.s L11
 ldc.i4.1
@@ -174,7 +174,7 @@ ldloc.0
 ldloc.s 4 (Sandbox.Engine.Physics.MyPhysicsBody)
 callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyPhysicsComponentBase::get_Entity()
 isinst VRage.Game.Entity.MyEntity
-stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+stfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 ldloc.2
 stloc.s 6 (Havok.HkRigidBody)
 ldloc.s 7 (VRageMath.Vector3)
@@ -182,7 +182,7 @@ call static VRageMath.Vector3 VRageMath.Vector3::op_UnaryNegation(VRageMath.Vect
 stloc.s 7 (VRageMath.Vector3)
 L11:
 ldloc.0
-ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 isinst Sandbox.Game.Entities.Character.MyCharacter
 stloc.s 8 (Sandbox.Game.Entities.Character.MyCharacter)
 ldloc.s 8 (Sandbox.Game.Entities.Character.MyCharacter)
@@ -215,7 +215,7 @@ L14:
 L16:
 L17:
 ldloc.0
-ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::other
+ldfld VRage.Game.Entity.MyEntity Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::other
 isinst Sandbox.Game.Entities.MyCubeGrid
 stloc.s 9 (Sandbox.Game.Entities.MyCubeGrid)
 ldloc.s 9 (Sandbox.Game.Entities.MyCubeGrid)
@@ -387,15 +387,15 @@ ldarg.0
 ldfld System.Single Sandbox.Game.Entities.Character.MyCharacter::m_canPlayImpact
 ldc.r4 0
 bgt.un L38
-newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_1::.ctor()
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_1::.ctor()
 ldarg.0
 ldc.r4 0.3
 stfld System.Single Sandbox.Game.Entities.Character.MyCharacter::m_canPlayImpact
 dup
 ldarg.1
 ldobj Havok.HkContactPointEvent
-stfld Havok.HkContactPointEvent Sandbox.Game.Entities.Character.<>c__DisplayClass463_1::hkContactPointEvent
-ldftn System.Boolean Sandbox.Game.Entities.Character.<>c__DisplayClass463_1::<RigidBody_ContactPointCallback>b__1()
+stfld Havok.HkContactPointEvent Sandbox.Game.Entities.Character.<>c__DisplayClass469_1::hkContactPointEvent
+ldftn System.Boolean Sandbox.Game.Entities.Character.<>c__DisplayClass469_1::<RigidBody_ContactPointCallback>b__1()
 newobj System.Void System.Func`1<System.Boolean>::.ctor(System.Object object, System.IntPtr method)
 stloc.s 35 (System.Func`1[System.Boolean])
 ldarg.0
@@ -521,42 +521,42 @@ ldloc.s 19 (System.Single)
 mul
 ldc.r4 2
 div
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldloc.s 14 (System.Single)
 ldc.r4 2
 ble.un.s L48
 ldloc.0
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 400
 sub
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 br.s L49
 L48:
 ldloc.s 14 (System.Single)
 ldc.r4 0
 bne.un.s L50
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 100
 ble.un.s L51
 ldloc.0
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 80
 div
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 L49:
 L50:
 L51:
 ldloc.0
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 10
 div
-stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+stfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldloc.0
-ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::impact
+ldfld System.Single Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::impact
 ldc.r4 1
 blt.un L52
 call static System.Boolean Sandbox.Game.Multiplayer.Sync::get_IsServer()
@@ -577,24 +577,56 @@ call static Sandbox.Engine.Physics.MyPhysicsBody Sandbox.Engine.Physics.MyPhysic
 callvirt VRage.ModAPI.IMyEntity VRage.Game.Components.MyPhysicsComponentBase::get_Entity()
 stloc.s 39 (VRage.ModAPI.IMyEntity)
 L54:
-call static Sandbox.Game.World.MySession Sandbox.Game.World.MySession::get_Static()
-ldfld VRage.Game.MyObjectBuilder_SessionSettings Sandbox.Game.World.MySession::Settings
-ldfld System.Boolean VRage.Game.MyObjectBuilder_SessionSettings::EnableFriendlyFire
-brtrue.s L55
 ldloc.s 39 (VRage.ModAPI.IMyEntity)
 isinst Sandbox.Game.Weapons.MyMissile
 dup
 stloc.s 40 (Sandbox.Game.Weapons.MyMissile)
+brfalse L55
+call static Sandbox.Game.World.MySession Sandbox.Game.World.MySession::get_Static()
+ldfld VRage.Game.MyObjectBuilder_SessionSettings Sandbox.Game.World.MySession::Settings
+ldfld System.Boolean VRage.Game.MyObjectBuilder_SessionSettings::EnableFriendlyFire
 brfalse.s L56
 ldloc.s 40 (Sandbox.Game.Weapons.MyMissile)
 ldarg.0
 call Sandbox.Game.World.MyIdentity Sandbox.Game.Entities.Character.MyCharacter::GetIdentity()
 callvirt System.Int64 Sandbox.Game.World.MyIdentity::get_IdentityId()
 callvirt virtual System.Boolean Sandbox.Game.Weapons.MyMissile::IsCharacterIdFriendly(System.Int64 charId)
-brtrue.s L57
-ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
+brtrue L57
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::.ctor()
+stloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
+ldloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
 ldloc.0
-ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<RigidBody_ContactPointCallback>b__2()
+stfld Sandbox.Game.Entities.Character.<>c__DisplayClass469_0 Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::CS$<>8__locals1
+ldloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
+ldloc.s 40 (Sandbox.Game.Weapons.MyMissile)
+callvirt virtual VRage.Game.MyDefinitionBase Sandbox.Game.Weapons.MyMissile::get_AmmoDefinition()
+ldflda VRage.Game.MyDefinitionId VRage.Game.MyDefinitionBase::Id
+ldfld VRage.Utils.MyStringHash VRage.Game.MyDefinitionId::SubtypeId
+stfld VRage.Utils.MyStringHash Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::sn
+ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
+ldloc.s 41 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_2)
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_2::<RigidBody_ContactPointCallback>b__3()
+newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
+ldstr "MyCharacter.DoDamage"
+ldc.i4.m1
+ldc.i4.0
+callvirt System.Void Sandbox.MySandboxGame::Invoke(System.Action action, System.String invokerName, System.Int32 startAtFrame, System.Int32 repeatTimes)
+ret
+L56:
+newobj System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::.ctor()
+stloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldloc.0
+stfld Sandbox.Game.Entities.Character.<>c__DisplayClass469_0 Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::CS$<>8__locals2
+ldloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldloc.s 40 (Sandbox.Game.Weapons.MyMissile)
+callvirt virtual VRage.Game.MyDefinitionBase Sandbox.Game.Weapons.MyMissile::get_AmmoDefinition()
+ldflda VRage.Game.MyDefinitionId VRage.Game.MyDefinitionBase::Id
+ldfld VRage.Utils.MyStringHash VRage.Game.MyDefinitionId::SubtypeId
+stfld VRage.Utils.MyStringHash Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::sn
+ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
+ldloc.s 42 (Sandbox.Game.Entities.Character.MyCharacter+<>c__DisplayClass469_3)
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_3::<RigidBody_ContactPointCallback>b__4()
 newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
 ldstr "MyCharacter.DoDamage"
 ldc.i4.m1
@@ -602,10 +634,9 @@ ldc.i4.0
 callvirt System.Void Sandbox.MySandboxGame::Invoke(System.Action action, System.String invokerName, System.Int32 startAtFrame, System.Int32 repeatTimes)
 ret
 L55:
-L56:
 ldsfld Sandbox.MySandboxGame Sandbox.MySandboxGame::Static
 ldloc.0
-ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass463_0::<RigidBody_ContactPointCallback>b__3()
+ldftn System.Void Sandbox.Game.Entities.Character.<>c__DisplayClass469_0::<RigidBody_ContactPointCallback>b__2()
 newobj System.Void System.Action::.ctor(System.Object object, System.IntPtr method)
 ldstr "MyCharacter.DoDamage"
 ldc.i4.m1

--- a/Shared/Patches/Conveyor/MyPathFindingSystemEnumeratorPatch.cs
+++ b/Shared/Patches/Conveyor/MyPathFindingSystemEnumeratorPatch.cs
@@ -1,9 +1,10 @@
 #if DEBUG
 
+// Patching generics does not work anymore
+#if DISABLED
+
 using HarmonyLib;
 using Sandbox.Game.GameSystems.Conveyors;
-using Shared.Config;
-using Shared.Plugin;
 using Shared.Tools;
 using VRage.Algorithms;
 
@@ -13,18 +14,13 @@ namespace Shared.Patches
     [HarmonyPatch(typeof(MyPathFindingSystem<IMyConveyorEndpoint>.Enumerator))]
     public static class MyPathFindingSystemEnumeratorPatch
     {
-        private static IPluginConfig Config => Common.Config;
-
-#if DEBUG
         private static readonly ConveyorStat Stat = new ConveyorStat();
         public static string Report(int period) => Stat.CountReport(period);
-#endif
 
         // ReSharper disable once UnusedMember.Local
         // ReSharper disable once InconsistentNaming
         [HarmonyPrefix]
         [HarmonyPatch(nameof(MyPathFindingSystem<IMyConveyorEndpoint>.Enumerator.MoveNext))]
-        [EnsureCode("05a0ee2c")]
         private static bool MoveNextPrefix(
             // object __instance,
             // ref bool __result,
@@ -35,12 +31,11 @@ namespace Shared.Patches
             // object ___m_edgeTraversable
         )
         {
-#if DEBUG
             Stat.CountCall();
-#endif
             return true;
         }
     }
 }
 
+#endif
 #endif

--- a/Shared/Patches/Conveyor/MyPathFindingSystemPatch.cs
+++ b/Shared/Patches/Conveyor/MyPathFindingSystemPatch.cs
@@ -1,5 +1,8 @@
 #if DEBUG
 
+// Patching generics does not work anymore
+#if DISABLED
+
 using HarmonyLib;
 using Sandbox.Game.GameSystems.Conveyors;
 using Shared.Config;
@@ -15,10 +18,8 @@ namespace Shared.Patches
     {
         private static IPluginConfig Config => Common.Config;
 
-#if DEBUG
         private static readonly ConveyorStat Stat = new ConveyorStat();
         public static string Report(int period) => Stat.FullReport(period);
-#endif
 
         // ReSharper disable once UnusedMember.Local
         // ReSharper disable once InconsistentNaming
@@ -27,9 +28,7 @@ namespace Shared.Patches
         [EnsureCode("d804599b")]
         private static bool ReachablePrefix()
         {
-#if DEBUG
             Stat.CountCall();
-#endif
             return true;
         }
 
@@ -40,14 +39,13 @@ namespace Shared.Patches
         [EnsureCode("d804599b")]
         private static void ReachablePostfix(bool __result)
         {
-#if DEBUG
             if (!__result)
             {
                 Stat.CountFailure();
             }
-#endif
         }
     }
 }
 
+#endif
 #endif

--- a/Shared/Patches/MergeAndPaste/MyGroupsPatch.cs
+++ b/Shared/Patches/MergeAndPaste/MyGroupsPatch.cs
@@ -1,3 +1,6 @@
+// Disabled due to inability to patch generics (methods of MyGroups)
+#if DISABLED
+
 using System.Runtime.CompilerServices;
 using System.Threading;
 using HarmonyLib;
@@ -61,3 +64,5 @@ namespace Shared.Patches
         }
     }
 }
+
+#endif

--- a/Shared/Patches/MergeAndPaste/MyResourceDistributorComponentPatch.cs
+++ b/Shared/Patches/MergeAndPaste/MyResourceDistributorComponentPatch.cs
@@ -1,3 +1,6 @@
+// Disabled due to inability to patch generics (methods of MyGroups)
+#if DISABLED
+
 using HarmonyLib;
 using Sandbox.Game.EntityComponents;
 using Shared.Config;
@@ -30,3 +33,5 @@ namespace Shared.Patches
         }
     }
 }
+
+#endif

--- a/Shared/Patches/PatchHelpers.cs
+++ b/Shared/Patches/PatchHelpers.cs
@@ -107,8 +107,8 @@ namespace Shared.Patches
                 log.Info($"- MySafeZonePatch IsActionAllowed: {MySafeZonePatch.IsActionAllowedCacheReport}");
                 log.Info($"- MySessionComponentSafeZonesPatch: {MySessionComponentSafeZonesPatch.CacheReport}");
                 log.Info($"- MyWindTurbinePatch: {MyWindTurbinePatch.CacheReport}");
-                log.Info($"- MyPathFindingSystemPatch: {MyPathFindingSystemPatch.Report(period)}");
-                log.Info($"- MyPathFindingSystemEnumeratorPatch: {MyPathFindingSystemEnumeratorPatch.Report(period)}");
+                // log.Info($"- MyPathFindingSystemPatch: {MyPathFindingSystemPatch.Report(period)}");
+                // log.Info($"- MyPathFindingSystemEnumeratorPatch: {MyPathFindingSystemEnumeratorPatch.Report(period)}");
                 log.Info($"- MyGridConveyorSystemPatch: {MyGridConveyorSystemPatch.PullItemReports}");
                 foreach (var report in MyGridConveyorSystemPatch.CacheReports)
                 {

--- a/Tests/App.config
+++ b/Tests/App.config
@@ -1,0 +1,146 @@
+﻿<?xml version="1.0" encoding="utf-8"?><configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Concurrent" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Debug" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tools" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Globalization" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Linq" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Linq.Expressions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Resources.ResourceManager" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Handles" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Numerics" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Parallel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -34,11 +34,11 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
+        <Reference Include="0Harmony, Version=2.3.3.0, Culture=neutral, processorArchitecture=MSIL">
+          <HintPath>..\packages\Lib.Harmony.2.3.3\lib\net48\0Harmony.dll</HintPath>
+        </Reference>
         <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
             <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-        </Reference>
-        <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-          <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="DirectShowLib, Version=2.1.0.1599, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\Bin64\DirectShowLib.dll</HintPath>
@@ -500,6 +500,10 @@
     <ItemGroup>
         <Compile Include="Properties\AssemblyInfo.cs"/>
         <Compile Include="Shared\Tools\RateLimiterTest.cs" />
+    </ItemGroup>
+    <ItemGroup>
+      <None Include="App.config" />
+      <None Include="packages.config" />
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
     <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Lib.Harmony" version="2.3.3" targetFramework="net481" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
 </packages>

--- a/TorchPlugin/Commands.cs
+++ b/TorchPlugin/Commands.cs
@@ -69,7 +69,7 @@ namespace TorchPlugin
             Respond($"grid_merge: {Format(config.FixGridMerge)}");
             Respond($"grid_paste: {Format(config.FixGridPaste)}");
             Respond($"gc: {Format(config.FixGarbageCollection)}");
-            Respond($"grid_groups: {Format(config.FixGridGroups)}");
+            // Respond($"grid_groups: {Format(config.FixGridGroups)}");
             Respond($"cache_mods: {Format(config.CacheMods)}");
             Respond($"cache_scripts: {Format(config.CacheScripts)}");
             Respond($"api_stats: {Format(config.DisableModApiStatistics)}");
@@ -185,9 +185,11 @@ namespace TorchPlugin
                     Config.FixGarbageCollection = parsedFlag;
                     break;
 
+                /* Disabled due to inability to patch generics (methods of MyGroups)
                 case "grid_groups":
                     Config.FixGridGroups = parsedFlag;
                     break;
+                */
 
                 case "cache_mods":
                     Config.CacheMods = parsedFlag;

--- a/TorchPlugin/ConfigView.xaml
+++ b/TorchPlugin/ConfigView.xaml
@@ -121,8 +121,10 @@
         <CheckBox Grid.Row="5" Grid.Column="0" Name="FixGarbageCollection" IsChecked="{Binding FixGarbageCollection}" Margin="5" />
         <TextBlock Grid.Row="5" Grid.Column="1" Text="Disable all explicit GC.* calls, which may cause long pauses on starting and stopping large worlds" VerticalAlignment="Center" Margin="5" />
 
+        <!-- Disabled FixGridGroups due to inability to patch generics (methods of MyGroups)
         <CheckBox Grid.Row="6" Grid.Column="0" Name="FixGridGroups" IsChecked="{Binding FixGridGroups}" Margin="5"/>
         <TextBlock Grid.Row="6" Grid.Column="1" Text="Disable resource updates while grids are being moved between groups" VerticalAlignment="Center" Margin="5"/>
+        -->
 
         <CheckBox Grid.Row="7" Grid.Column="0" Name="CacheMods" IsChecked="{Binding CacheMods}" Margin="5"/>
         <TextBlock Grid.Row="7" Grid.Column="1" Text="Caches compiled mods for faster world load" VerticalAlignment="Center" Margin="5"/>
@@ -197,8 +199,7 @@
         <TextBlock Grid.Row="37" Grid.Column="1" Text="grid_paste" VerticalAlignment="Center" Margin="5" />
         <TextBlock Grid.Row="38" Grid.Column="1" Text="gc" VerticalAlignment="Center" Margin="5" />
         <TextBlock Grid.Row="39" Grid.Column="1" Text="api_stats" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="40" Grid.Column="1" Text="grid_groups" VerticalAlignment="Center" Margin="5" />
-        <TextBlock Grid.Row="41" Grid.Column="1" Text="grid_groups" VerticalAlignment="Center" Margin="5" />
+        <!-- <TextBlock Grid.Row="40" Grid.Column="1" Text="grid_groups" VerticalAlignment="Center" Margin="5" /> -->
         <TextBlock Grid.Row="42" Grid.Column="1" Text="cache_mods" VerticalAlignment="Center" Margin="5" />
         <TextBlock Grid.Row="43" Grid.Column="1" Text="cache_scripts" VerticalAlignment="Center" Margin="5" />
         <TextBlock Grid.Row="44" Grid.Column="1" Text="safe_zone" VerticalAlignment="Center" Margin="5" />

--- a/TorchPlugin/Plugin.cs
+++ b/TorchPlugin/Plugin.cs
@@ -86,7 +86,7 @@ namespace TorchPlugin
             }
 #endif
 
-            sessionManager = torch.Managers.GetManager<TorchSessionManager>();
+            sessionManager = (TorchSessionManager) torch.Managers.GetManager(typeof(TorchSessionManager));
             sessionManager.SessionStateChanged += SessionStateChanged;
 
             initialized = true;

--- a/TorchPlugin/PluginConfig.cs
+++ b/TorchPlugin/PluginConfig.cs
@@ -78,7 +78,8 @@ namespace TorchPlugin
             set => SetValue(ref fixGarbageCollection, value);
         }
 
-        [Display(Order = 7, GroupName = "Fixes", Name = "Fix grid groups", Description = "Disable resource updates while grids are being moved between groups")]
+        // Disabled due to inability to patch generics (methods of MyGroups)
+        [Display(Order = 7, GroupName = "Fixes", Name = "Fix grid groups", Description = "Disable resource updates while grids are being moved between groups", Enabled = false)]
         public bool FixGridGroups
         {
             get => fixGridGroups;

--- a/TorchPlugin/Properties/AssemblyInfo.cs
+++ b/TorchPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.7.0")]
-[assembly: AssemblyFileVersion("1.11.7.0")]
+[assembly: AssemblyVersion("1.11.8.0")]
+[assembly: AssemblyFileVersion("1.11.8.0")]

--- a/TorchPlugin/TorchPlugin.csproj
+++ b/TorchPlugin/TorchPlugin.csproj
@@ -33,8 +33,8 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-          <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
+        <Reference Include="0Harmony, Version=2.3.3.0, Culture=neutral, processorArchitecture=MSIL">
+          <HintPath>..\packages\Lib.Harmony.2.3.3\lib\net48\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, PublicKeyToken=null">
           <HintPath>..\Torch\ControlzEx.dll</HintPath>

--- a/TorchPlugin/manifest.xml
+++ b/TorchPlugin/manifest.xml
@@ -3,5 +3,5 @@
   <Name>PerformanceImprovements</Name>
   <Guid>c2cf3ed2-c6ac-4dbd-ab9a-613a1ef67784</Guid>
   <Repository>PerformanceImprovements</Repository>
-  <Version>v1.11.7.0</Version>
+  <Version>v1.11.8.0</Version>
 </PluginManifest>

--- a/TorchPlugin/packages.config
+++ b/TorchPlugin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.2.2" targetFramework="net48" />
+  <package id="Lib.Harmony" version="2.3.3" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net481" />
 </packages>


### PR DESCRIPTION
- Harmony 2.3.3
- Disabled `FixGridGroups` due to inability to patch generics (methods of `MyGroups`)
- Disabled patching generics in `DEBUG` only code (no effect on functionality)
- Accepted code change in `MyCharacter.RigidBody_ContactPointCallback`