### PR TITLE
1.11.13

### DIFF
--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.12.0")]
-[assembly: AssemblyFileVersion("1.11.12.0")]
+[assembly: AssemblyVersion("1.11.13.0")]
+[assembly: AssemblyFileVersion("1.11.13.0")]

--- a/DedicatedPlugin/Properties/AssemblyInfo.cs
+++ b/DedicatedPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.12.0")]
-[assembly: AssemblyFileVersion("1.11.12.0")]
+[assembly: AssemblyVersion("1.11.13.0")]
+[assembly: AssemblyFileVersion("1.11.13.0")]

--- a/Shared/Plugin/Common.cs
+++ b/Shared/Plugin/Common.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using Shared.Config;
 using Shared.Logging;
 using Shared.Patches;
@@ -14,44 +15,66 @@ namespace Shared.Plugin
         public static IPluginLogger Logger { get; private set; }
         public static IPluginConfig Config { get; private set; }
 
-        public static string GameVersion;
-        
-        public static string DataDir;
-        public static string CacheDir;
+        public static string GameVersion { get; private set; }
+        public static string PluginVersion { get; private set; }
+
+        public static string DataDir { get; private set; }
+        public static string CacheDir { get; private set; }
+        public static string DebugDir { get; private set; }
 
         private static string CacheGameVersionPath => Path.Combine(CacheDir, "GameVersion.txt");
+        private static string PluginVersionPath => Path.Combine(DebugDir, "PluginVersion.txt");
 
         public static void SetPlugin(ICommonPlugin plugin, string gameVersion, string storageDir)
         {
             Plugin = plugin;
             Logger = plugin.Log;
             Config = plugin.Config;
-            
+
             GameVersion = gameVersion;
+            PluginVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetCallingAssembly().Location).FileVersion;
 
             DataDir = Path.Combine(storageDir, "PerformanceImprovements");
             CacheDir = Path.Combine(DataDir, "Cache");
+            DebugDir = Path.Combine(DataDir, "Debug");
 
-            CleanupCache();
-            
+            var hasGameVersionChanged = !File.Exists(CacheGameVersionPath) || File.ReadAllText(CacheGameVersionPath) != GameVersion;
+            var hasPluginVersionChanged = !File.Exists(PluginVersionPath) || File.ReadAllText(PluginVersionPath) != PluginVersion;
+
+            CleanupCache(hasGameVersionChanged);
+            CleanupDebug(hasGameVersionChanged || hasPluginVersionChanged);
+
             PatchHelpers.Configure();
         }
 
-        private static void CleanupCache()
+        private static void CleanupCache(bool clear)
         {
             Directory.CreateDirectory(CacheDir);
-
-            var hasVersionChanged = !File.Exists(CacheGameVersionPath) || File.ReadAllText(CacheGameVersionPath) != GameVersion;
 
             var now = DateTime.UtcNow;
             foreach (var path in Directory.EnumerateFiles(CacheDir, "*.cache", SearchOption.AllDirectories))
             {
-                if (hasVersionChanged || (now - File.GetCreationTimeUtc(path)).TotalDays >= CacheExpirationDays)
+                if (clear || (now - File.GetCreationTimeUtc(path)).TotalDays >= CacheExpirationDays)
                     File.Delete(path);
             }
 
-            if (hasVersionChanged)
+            if (clear)
                 File.WriteAllText(CacheGameVersionPath, GameVersion);
+        }
+
+        private static void CleanupDebug(bool clear)
+        {
+            Directory.CreateDirectory(DebugDir);
+
+            if (!clear)
+                return;
+
+            foreach (var path in Directory.EnumerateFiles(DebugDir, "*.il", SearchOption.AllDirectories))
+            {
+                File.Delete(path);
+            }
+
+            File.WriteAllText(PluginVersionPath, PluginVersion);
         }
     }
 }

--- a/TorchPlugin/Properties/AssemblyInfo.cs
+++ b/TorchPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.12.0")]
-[assembly: AssemblyFileVersion("1.11.12.0")]
+[assembly: AssemblyVersion("1.11.13.0")]
+[assembly: AssemblyFileVersion("1.11.13.0")]

--- a/TorchPlugin/manifest.xml
+++ b/TorchPlugin/manifest.xml
@@ -3,5 +3,5 @@
   <Name>PerformanceImprovements</Name>
   <Guid>c2cf3ed2-c6ac-4dbd-ab9a-613a1ef67784</Guid>
   <Repository>PerformanceImprovements</Repository>
-  <Version>v1.11.12.0</Version>
+  <Version>v1.11.13.0</Version>
 </PluginManifest>


### PR DESCRIPTION
- Transpiler patches record the original and patched IL code in the `Debug` data folder for forensics. The folder is cleared each time when the version of the game or the plugin changes.